### PR TITLE
(Bugfix) Support OutputStream.write(int byte) / InputStream.read()

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -182,6 +182,16 @@ public class ZstdInputStream extends FilterInputStream {
         return size;
     }
 
+    public int read() throws IOException {
+        byte[] oneByte = new byte[1];
+        int result = read(oneByte, 0, 1);
+        if (result > 0) {
+            return oneByte[0] & 0xff;
+        } else {
+            return result;
+        }
+    }
+
     public int available() throws IOException {
         if (legacy != null) return legacy.available();
         return oEnd - oPos;

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -97,6 +97,12 @@ public class ZstdOutputStream extends FilterOutputStream {
         }
     }
 
+    public void write(int i) throws IOException {
+        byte[] oneByte = new byte[1];
+        oneByte[0] = (byte) i;
+        write(oneByte, 0, 1);
+    }
+
     /**
      * Flushes the output
      *

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -163,7 +163,8 @@ class ZstdSpec extends FlatSpec with Checkers {
       assert(zis.skip(0) == 0)
       val length = orig.length.toInt
       val buff = Array.fill[Byte](length)(0)
-      var pos  = 0;
+      buff(0)  = zis.read().toByte
+      var pos  = 1;
       while (pos < length) {
         pos += zis.read(buff, pos, length - pos)
       }
@@ -184,7 +185,8 @@ class ZstdSpec extends FlatSpec with Checkers {
       assert(zis.skip(0) == 0)
       val length = orig.length.toInt
       val buff = Array.fill[Byte](length)(0)
-      var pos  = 0;
+      buff(0)  = zis.read().toByte
+      var pos  = 1;
       while (pos < length) {
         pos += zis.read(buff, pos, length - pos)
       }

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -135,7 +135,8 @@ class ZstdSpec extends FlatSpec with Checkers {
 
       val os  = new ByteArrayOutputStream(Zstd.compressBound(file.length).toInt)
       val zos = new ZstdOutputStream(os, level)
-      zos.write(buff)
+      zos.write(buff(0).toInt)
+      zos.write(buff, 1, length - 1)
       zos.flush
       zos.close
 


### PR DESCRIPTION
The current In/OutputStream implementations fail to override read() and write(int), which leads to these methods being forwarded directly to the underlying stream, bypassing Zstd entirely.

This leads to corrupted files during output and mysterious errors during input.

One example of code using InputSteam.read() in the wild is Google ProtoBuffers' "parseDelimitedFrom(InputStream)" method, but there are probably others.