### PR TITLE
Fix Issue #16: Implement support for directe ByteBuffers

### DIFF
--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -41,12 +41,6 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_compressDirectByteBuffer
     char *src_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, src_buf);
     if (src_buf_ptr == NULL) goto E1;
 
-    printf("compress: dst=0x%p dst_offset=%d src_buf=%p src_offset=%d dst_ptr=%p\n",
-        dst_buf_ptr, dst_offset, src_buf_ptr, src_offset, dst_buf_ptr + dst_offset);
-    if (src_size == 1) {
-        printf("compress: source byte is 0x%x\n", src_buf_ptr[0]);
-    }
-    fflush(stdout);
     size = ZSTD_compress(dst_buf_ptr + dst_offset, (size_t) dst_size, src_buf_ptr + src_offset, (size_t) src_size, (int) level);
 E1: return size;
 }
@@ -80,8 +74,6 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressDirectByteBuff
   (JNIEnv *env, jclass obj, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
     size_t size = (size_t)ERROR(memory_allocation);
 
-    printf("decompress: decompressing direct byte buffer\n");
-
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst_buf);
     if (dst_offset + dst_size > dst_cap) return ERROR(dstSize_tooSmall);
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src_buf);
@@ -91,13 +83,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressDirectByteBuff
     char *src_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, src_buf);
     if (src_buf_ptr == NULL) goto E1;
 
-    printf("decompress: dst=0x%p dst_offset=%d src_buf=%p src_offset=%d dst_ptr=%p\n",
-        dst_buf_ptr, dst_offset, src_buf_ptr, src_offset, dst_buf_ptr + dst_offset);
     size = ZSTD_decompress(dst_buf_ptr + dst_offset, (size_t) dst_size, src_buf_ptr + src_offset, (size_t) src_size);
-    if (size == 1) {
-        printf("decompress: dest byte is 0x%x\n", dst_buf_ptr[0]);
-    }
-    fflush(stdout);
 E1: return size;
 }
 

--- a/src/test/scala/Perf.scala
+++ b/src/test/scala/Perf.scala
@@ -63,7 +63,7 @@ class ZstdPerfSpec extends FlatSpec  {
       inputBuffer.rewind()
       val compressedBuffer  = Zstd.compress(inputBuffer, level)
       nsc += System.nanoTime - start_c
-      compressedSize  = compressedBuffer.position()
+      compressedSize  = compressedBuffer.limit()
       val start_d     = System.nanoTime
       outputBuffer.clear()
       val size        = Zstd.decompress(outputBuffer, compressedBuffer)

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -119,7 +119,6 @@ class ZstdSpec extends FlatSpec with Checkers with Whenever {
 
       compressedBuffer.flip()
       for ((level, compresedSize) <- levels.zip(compressedSizes)) {
-        println(s"level=${level} compressedSize=${compresedSize}")
         val oldCompressedPosition = compressedBuffer.position()
         val oldDecompressedPosition = decompressedBuffer.position()
 

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -5,6 +5,8 @@ import org.scalatest.prop.Checkers
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
 import java.io._
+import java.nio.ByteBuffer
+
 import scala.io._
 import scala.collection.mutable.WrappedArray
 
@@ -25,6 +27,139 @@ class ZstdSpec extends FlatSpec with Checkers {
           input.toSeq == decompressed.toSeq
         }
       }
+    }
+
+    it should s"round-trip compression/decompression with ByteBuffers at level $level" in {
+      check { input: Array[Byte] =>
+        {
+          val size        = input.length
+          val inputBuffer = ByteBuffer.allocateDirect(size)
+          inputBuffer.put(input)
+          inputBuffer.rewind()
+          val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size).toInt)
+          val decompressedBuffer = ByteBuffer.allocateDirect(size)
+
+          val compressedSize = Zstd.compress(compressedBuffer, inputBuffer, level)
+
+          compressedBuffer.flip()
+          val decompressedSize = Zstd.decompress(decompressedBuffer, compressedBuffer)
+          assert(decompressedSize == input.length)
+
+          inputBuffer.rewind()
+          compressedBuffer.rewind()
+          decompressedBuffer.flip()
+
+          val comparison = inputBuffer.compareTo(decompressedBuffer)
+          val result = comparison == 0 && Zstd.decompressedSize(compressedBuffer) == decompressedSize
+          result
+        }
+      }
+    }
+
+    it should s"compress with a byte[] and uncompress with a ByteBuffer $level" in {
+      check { input: Array[Byte] =>
+        val size = input.length
+        val compressed = Zstd.compress(input, level)
+
+        val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size.toLong).toInt)
+        compressedBuffer.put(compressed)
+        compressedBuffer.limit(compressedBuffer.position())
+        compressedBuffer.rewind()
+
+        val decompressedBuffer = Zstd.decompress(compressedBuffer, size)
+        val decompressed = new Array[Byte](size)
+        decompressedBuffer.get(decompressed)
+        input.toSeq == decompressed.toSeq
+      }
+    }
+
+    it should s"compress with a ByteBuffer and uncompress with a byte[] $level" in {
+      check { input: Array[Byte] =>
+        val size        = input.length
+        val inputBuffer = ByteBuffer.allocateDirect(size)
+        inputBuffer.put(input)
+        inputBuffer.rewind()
+        val compressedBuffer  = Zstd.compress(inputBuffer, level)
+        val compressed = new Array[Byte](compressedBuffer.limit() - compressedBuffer.position())
+        compressedBuffer.get(compressed)
+
+        val decompressed = Zstd.decompress(compressed, size)
+        input.toSeq == decompressed.toSeq
+      }
+    }
+  }
+
+  it should s"honor non-zero position and limit values in ByteBuffers" in {
+    check { input: Array[Byte] =>
+      val size = input.length
+
+      //The test here is to compress the input at each of the designated levels, with each new compressed version
+      //being added to the same buffer as the one before it, one after the other.  Then decompress the same way.
+      //This verifies that the ByteBuffer-based versions behave the way one expects, honoring and updating position
+      //and limit as they go
+      val inputBuffer = ByteBuffer.allocateDirect(size)
+      inputBuffer.put(input)
+      inputBuffer.rewind()
+      val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size).toInt * levels.size)
+      val decompressedBuffer = ByteBuffer.allocateDirect(size * levels.size)
+
+      val compressedSizes = for (level <- levels) yield {
+        inputBuffer.rewind()
+
+        val oldCompressedPosition = compressedBuffer.position()
+        val oldInputPosition = inputBuffer.position()
+
+        val compressedSize = Zstd.compress(compressedBuffer, inputBuffer, level)
+
+        assert(inputBuffer.position() == oldInputPosition + size)
+        assert(compressedBuffer.position() == oldCompressedPosition + compressedSize)
+
+        compressedSize
+      }
+
+      compressedBuffer.flip()
+      for ((level, compresedSize) <- levels.zip(compressedSizes)) {
+        println(s"level=${level} compressedSize=${compresedSize}")
+        val oldCompressedPosition = compressedBuffer.position()
+        val oldDecompressedPosition = decompressedBuffer.position()
+
+        //This isn't using the streaming mode, so zstd expects the entire contents of the buffer to be one
+        //zstd compressed output.  For this test we've stacked the compressed outputs one after the other.
+        //Use limit to mark where the end of this particular compresssed output can be found.
+        //Note that the duplicate() call doesn't copy memory; it just makes a duplicate ByteBuffer pointing to the same
+        //location in memory
+        val thisChunkBuffer = compressedBuffer.duplicate()
+        thisChunkBuffer.limit(thisChunkBuffer.position() + compresedSize)
+        val decompressedSize = Zstd.decompress(decompressedBuffer, thisChunkBuffer)
+
+        assert(decompressedSize == input.length)
+        compressedBuffer.position(thisChunkBuffer.position)
+        assert(compressedBuffer.position() == oldCompressedPosition + compresedSize)
+        assert(decompressedBuffer.position() == oldDecompressedPosition + size)
+      }
+
+      //At this point the decompressedBuffer's position should equal it's limit.
+      //flip it and verify it has one copy of the input for each of the levels that were compressed
+      assert(decompressedBuffer.hasRemaining == false)
+      decompressedBuffer.flip()
+
+      for (level <- levels) {
+        val slice = decompressedBuffer.slice()
+        slice.limit(size)
+        inputBuffer.rewind()
+
+        val expected = new Array[Byte](size)
+        inputBuffer.get(expected)
+        val actual = new Array[Byte](size)
+        slice.get(actual)
+
+        assert(actual.toSeq == expected.toSeq)
+        decompressedBuffer.position(decompressedBuffer.position() + size)
+      }
+
+      assert(decompressedBuffer.position() == levels.size * size)
+      assert(!decompressedBuffer.hasRemaining)
+      true
     }
   }
 


### PR DESCRIPTION
The details of this change are described in the issue #16 .

This adds overloads to `compress` and `decompress` that operate on `ByteBuffer`s instead of `byte[]`s. 