### PR TITLE
Increment version number to reflect additional API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "zstd-jni"
 
-version := "1.1.0"
+version := "1.2.0"
 
 scalaVersion := "2.11.8"
 


### PR DESCRIPTION
SemVer guidelines dictate that the addition of new API functionality that is non-breaking, like the change in PR #17, increment the minor version number.  This will also ensure the updated bits are resolved via Maven Central regardless of aggressive caching by intermediate proxies like Artifactory.
