### PR TITLE
Release the ByteBuffer a bit more explicitly

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
@@ -126,6 +126,7 @@ public class ZstdDirectBufferCompressingStream implements Closeable, Flushable {
             finally {
                 freeCStream(stream);
                 closed = true;
+                target = null; // help GC with realizing the buffer can be released
             }
         }
     }

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStream.java
@@ -114,6 +114,7 @@ public class ZstdDirectBufferDecompressingStream implements Closeable {
     protected void finalize() throws Throwable {
         if (!closed) {
             freeDStream(stream);
+            source = null; // help GC with realizing the buffer can be released
         }
     }
 }


### PR DESCRIPTION
I was reading a bit more about [how direct ByteBuffers are released](https://stackoverflow.com/questions/36077641/java-when-does-direct-buffer-released), and thought to help the GC a bit with explicitly clearing the field with the pointer to the buffer.