### PR TITLE
Add CMake to support cross compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+project(zstd-jni)
+
+add_subdirectory(src/main/native)

--- a/src/main/native/CMakeLists.txt
+++ b/src/main/native/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.5)
+
+# Override setting in Poky cmake.bbclass
+# This allows us to search for javac in the host system root.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+
+# Detects Java home directory, based on javac location.
+find_program(javac javac)
+get_filename_component(JAVA_HOME ${javac} REALPATH)
+get_filename_component(JAVA_HOME ${JAVA_HOME} DIRECTORY)
+get_filename_component(JAVA_HOME ${JAVA_HOME}/.. ABSOLUTE)
+message(STATUS "Java home: ${JAVA_HOME}")
+
+set(SOURCES
+  jni_directbufferdecompress_zstd.c
+  jni_fast_zstd.c
+  jni_inputstream_zstd.c
+  jni_outputstream_zstd.c
+  jni_zdict.c
+  jni_zstd.c
+  common/entropy_common.c
+  common/error_private.c
+  common/fse_decompress.c
+  common/pool.c
+  common/threading.c
+  common/xxhash.c
+  common/zstd_common.c
+  compress/fse_compress.c
+  compress/huf_compress.c
+  compress/zstd_compress.c
+  compress/zstdmt_compress.c
+  decompress/huf_decompress.c
+  decompress/zstd_decompress.c
+  dictBuilder/cover.c
+  dictBuilder/divsufsort.c
+  dictBuilder/zdict.c
+  legacy/zstd_v04.c
+  legacy/zstd_v05.c
+  legacy/zstd_v06.c
+  legacy/zstd_v07.c)
+
+add_library(zstd-jni SHARED ${SOURCES})
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/legacy
+  ${JAVA_HOME}/include ${JAVA_HOME}/include/linux)
+
+target_compile_definitions(zstd-jni PRIVATE ZSTD_LEGACY_SUPPORT=4)
+
+install(TARGETS zstd-jni LIBRARY DESTINATION lib)


### PR DESCRIPTION
This pull request adds CMake files that make cross compiling easier, since I couldn't make `sbt compile` work with my cross compiler environment (in my case Yocto).

Usage
```
mkdir builddir
cd builddir
cmake ..
make
```
I'm aware that a parallel build system to sbt is not an optimal solution, so I don't know if this pull request is appropriate. But at least it fixes my cross compiling issues :-)