### PR TITLE
Training with direct byte buffer samples

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -308,6 +308,17 @@ public class Zstd {
      */
     public static native long trainFromBuffer(byte[][] samples, byte[] dictBuffer);
 
+    /**
+     * Creates a new dictionary to tune a kind of samples
+     *
+     * @param samples the samples direct byte buffer array
+     * @param sampleSizes java integer array of sizes
+     * @param dictBuffer the new dictionary buffer (preallocated direct byte buffer)
+     * @return the number of bytes into buffer 'dictBuffer' or an error code if
+     *          it fails (which can be tested using ZSTD_isError())
+     */
+    public static native long trainFromBufferDirect(ByteBuffer samples, int[] sampleSizes, ByteBuffer dictBuffer);
+
     /* Constants from the zstd_static header */
     public static native int magicNumber();
     public static native int windowLogMin();

--- a/src/main/java/com/github/luben/zstd/ZstdDictTrainer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictTrainer.java
@@ -1,0 +1,61 @@
+package com.github.luben.zstd;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ZstdDictTrainer {
+    private final int allocatedSize;
+    private final ByteBuffer trainingSamples;
+    private final List<Integer> sampleSizes;
+    private final int dictSize;
+    private long filledSize;
+
+    public ZstdDictTrainer(int sampleSize, int dictSize) {
+        trainingSamples = ByteBuffer.allocateDirect(sampleSize);
+        sampleSizes =  new ArrayList<>();
+        this.allocatedSize = sampleSize;
+        this.dictSize = dictSize;
+    }
+
+    public boolean addSample(byte[] sample) {
+        if (filledSize + sample.length > allocatedSize) {
+            return false;
+        }
+        trainingSamples.put(sample);
+        sampleSizes.add(sample.length);
+        filledSize += sample.length;
+        return true;
+    }
+
+    public ByteBuffer trainSamplesDirect() {
+        ByteBuffer dictBuffer = ByteBuffer.allocateDirect(dictSize);
+        long l = Zstd.trainFromBufferDirect(trainingSamples, copyToIntArray(sampleSizes), dictBuffer);
+        if (Zstd.isError(l)) {
+            dictBuffer.limit(0);
+            // TODO: throw exception here?
+            return null;
+        }
+        dictBuffer.limit(Long.valueOf(l).intValue());
+        return dictBuffer;
+    }
+
+    public byte[] trainSamples() {
+        ByteBuffer byteBuffer = trainSamplesDirect();
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes);
+        return bytes;
+    }
+
+    private int[] copyToIntArray(List<Integer> list) {
+        int[] ints = new int[list.size()];
+        int idx = 0;
+        for (Integer i: list) {
+            ints[idx] = i;
+            idx++;
+        }
+        return ints;
+    }
+
+
+}

--- a/src/main/native/jni_zdict.c
+++ b/src/main/native/jni_zdict.c
@@ -43,3 +43,30 @@ E2: free(samples_sizes);
 E1: return size;
 }
 
+JNIEXPORT jlong Java_com_github_luben_zstd_Zstd_trainFromBufferNative
+  (JNIEnv *env, jclass obj, jobject samples, jintArray sampleSizes, jobject dictBuffer) {
+
+    jbyte* samples_buffer = (jbyte *) (*env)->GetDirectBufferAddress(env, samples);
+    size_t samples_buffer_size = (*env)->GetDirectBufferCapacity(env, sampleSizes);
+
+    jbyte* dict_buff = (jbyte * ) (*env)->GetDirectBufferAddress(env, dictBuffer);
+    size_t dict_capacity = (*env)->GetDirectBufferCapacity(env, dictBuffer);
+
+    jsize num_samples = (*env)->GetArrayLength(env, sampleSizes);
+    jint *sample_sizes_array = (*env)->GetIntArrayElements(env, sampleSizes, 0);
+    size_t *samples_sizes = malloc(sizeof(size_t) * num_samples);
+    if (!samples_sizes) {
+        jclass eClass = (*env)->FindClass(env, "Ljava/lang/OutOfMemoryError;");
+        (*env)->ThrowNew(env, eClass, "native heap");
+        goto E1;
+    }
+    for (int i = 0; i < num_samples; i++) {
+        samples_sizes[i] = sample_sizes_array[i];
+    }
+   (*env)->ReleaseIntArrayElements(env, sampleSizes, sample_sizes_array, 0);
+
+    size_t size = ZDICT_trainFromBuffer(dict_buff, dict_capacity, samples_buffer, samples_sizes, num_samples);
+E2: free(samples_sizes);
+E1: return size;
+}
+

--- a/src/main/native/jni_zdict.c
+++ b/src/main/native/jni_zdict.c
@@ -43,7 +43,7 @@ E2: free(samples_sizes);
 E1: return size;
 }
 
-JNIEXPORT jlong Java_com_github_luben_zstd_Zstd_trainFromBufferNative
+JNIEXPORT jlong Java_com_github_luben_zstd_Zstd_trainFromBufferDirect
   (JNIEnv *env, jclass obj, jobject samples, jintArray sampleSizes, jobject dictBuffer) {
 
     jbyte* samples_buffer = (jbyte *) (*env)->GetDirectBufferAddress(env, samples);


### PR DESCRIPTION
Attempting to add ability to use native byte buffers for training as copying large arrays causes JVM to stall. 

My familiarity with JNI is low. Would appreciate assistance.

It looks like the tests are running but they never finish running into this non-stop error message:

Cover must have at least one input file
Cover must have at least one input file
Cover must have at least one input file
Cover must have at least one input file
Cover must have at least one input file
Cover must have at least one input file


