### PR TITLE
Clean up temporary native library on Linux. Does not work on Windows

### DIFF
--- a/src/main/java/com/github/luben/zstd/util/Native.java
+++ b/src/main/java/com/github/luben/zstd/util/Native.java
@@ -108,7 +108,6 @@ public enum Native {
                     System.loadLibrary(libnameShort);
                 } catch (UnsatisfiedLinkError e1) {
                     // display error in case problem with loading from temp folder
-                    e.printStackTrace();
                     throw linkError(e1);
                 }
             }


### PR DESCRIPTION
On Linux & Mac, tempLib.delete() will delete temp native library after it is loaded. deleteOnExit() is ineffective but left it just in case.

Neither works on Windows. More info here:
https://stackoverflow.com/questions/33226381/cannot-delete-a-temporary-file-when-it-is-used-to-load-a-system-library
https://stackoverflow.com/questions/453359/how-to-unload-library-dll-from-java-jvm