### PR TITLE
Release the mutex also when no dict results from analysis.

### DIFF
--- a/src/main/native/dictBuilder/cover.c
+++ b/src/main/native/dictBuilder/cover.c
@@ -919,13 +919,12 @@ void COVER_best_finish(COVER_best_t *best, ZDICT_cover_params_t parameters,
         }
       }
       /* Save the dictionary, parameters, and size */
-      if (!dict) {
-        return;
+      if (dict) {
+        memcpy(best->dict, dict, dictSize);
+        best->dictSize = dictSize;
+        best->parameters = parameters;
+        best->compressedSize = compressedSize;
       }
-      memcpy(best->dict, dict, dictSize);
-      best->dictSize = dictSize;
-      best->parameters = parameters;
-      best->compressedSize = compressedSize;
     }
     if (liveJobs == 0) {
       ZSTD_pthread_cond_broadcast(&best->cond);

--- a/src/test/scala/ZstdDict.scala
+++ b/src/test/scala/ZstdDict.scala
@@ -28,6 +28,17 @@ class ZstdDictSpec extends FlatSpec {
     dict
   }
 
+  "Zstd" should "report error when failing to make a dict" in {
+    val src = source.sliding(28, 28).take(8).map(_.toArray)
+    val trainer = new ZstdDictTrainer(1024 * 1024, 32 * 1024)
+    for (sample <- src) {
+      trainer.addSample(sample)
+    }
+    intercept[com.github.luben.zstd.ZstdException] {
+      trainer.trainSamples(false)
+    }
+  }
+
   val input = source.toArray
   val legacyS = List(true, false)
   val levels = List(1)


### PR DESCRIPTION
I have added a test that made the test hang before the change to the native code.

The modification of the cover.c code changes the abrupt return in the bad-case into just not storing the dict and returning through the same cleanup as the good case uses. The test then no longer gets stuck.

I hit this in production from trying to make a dict from too little entropy it seems.(?)