### PR TITLE
Guaranteed Zstd Context Clousure and No Operation allowed after Clousure

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -216,21 +216,24 @@ public class ZstdOutputStream extends FilterOutputStream {
         if (isClosed) {
             return;
         }
-        if (!frameClosed) {
-            // compress the remaining input and close the frame
-            int size;
-            do {
-                size = endStream(stream, dst, dstSize);
-                if (Zstd.isError(size)) {
-                    throw new IOException("Compression error: " + Zstd.getErrorName(size));
-                }
-                out.write(dst, 0, (int) dstPos);
-            } while (size > 0);
+        try {
+            if (!frameClosed) {
+                // compress the remaining input and close the frame
+                int size;
+                do {
+                    size = endStream(stream, dst, dstSize);
+                    if (Zstd.isError(size)) {
+                        throw new IOException("Compression error: " + Zstd.getErrorName(size));
+                    }
+                    out.write(dst, 0, (int) dstPos);
+                } while (size > 0);
+            }
+            out.close();
+        } finally {
+            // release the resources even if underlying stream throw an exception
+            isClosed = true;
+            freeCStream(stream);
         }
-        // release the resources
-        freeCStream(stream);
-        out.close();
-        isClosed = true;
     }
 
     @Override


### PR DESCRIPTION
This will fix both #83 and #119 . It guaranteed to close the opaque pointer to Zstd context object on close call and will set isClosed flag before cleaning the context from native code using freeCStream.
Hence this will prohibit the JVM crashes and Memory leaks. The finalize call will skip the close if the stream is already closed.