### PR TITLE
Guaranteed Zstd Context Clousure and No Operation allowed after Clousure

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -234,9 +234,9 @@ public class ZstdInputStream extends FilterInputStream {
         if (isClosed) {
             return;
         }
+        isClosed = true;
         freeDStream(stream);
         in.close();
-        isClosed = true;
     }
 
     @Override


### PR DESCRIPTION
Doing the same in ZstdInputStream as well, in.close throws IOException due to underlying stream issue and we may free  `freeDStream(stream)` without marking `isClosed = true` , This will also crash the JVM.