### PR TITLE
Fix infinite loop in continuous mode when reading an incomplete frame.

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -149,7 +149,11 @@ public class ZstdInputStream extends FilterInputStream {
                     if (frameFinished) {
                         return -1;
                     } else if (isContinuous) {
-                        return (int)(dstPos - offset);
+                        srcSize = (int)(dstPos - offset);
+                        if (srcSize > 0) {
+                            return (int) srcSize;
+                        }
+                        return -1;
                     } else {
                         throw new IOException("Read error or truncated source");
                     }


### PR DESCRIPTION
Without this fix, the attached unit test goes into an infinite loop. This is because `readInternal` would return 0 [here](https://github.com/tgregg/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/ZstdInputStream.java#L152), causing it to forever satisfy the condition of the [while loop](https://github.com/tgregg/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/ZstdInputStream.java#L119) in `read` because additional bytes never become available in the underlying InputStream.

This is not a typical case, as continuous mode would typically be used when a different thread or process is producing the stream. Eventually the bytes that complete the frame will come available and the loop will break.

However, in exceptional conditions, those bytes may never arrive. For example, say a different process is writing the file that is being read in continuous mode. That process dies in the middle of a flush, and the stream is incomplete. In that case, the ZstdInputStream over that file would spin forever waiting for the stream to complete, even though it never will.

This solution proposes returning -1 from `read` in this case. This allows the caller to decide how long to keep retrying before giving up gracefully.