### PR TITLE
Add test for calculating decompressedDirectByteBufferSize via offset

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -580,7 +580,7 @@ public class Zstd {
      *
      * @param src the compressed buffer
      * @param srcPosition offset of the compressed data inside the src buffer
-     * @param srcSize length of the compressed buffer
+     * @param srcSize length of the compressed data inside the src buffer
      * @return the number of bytes of the original buffer
      *         0 if the original size is not known
      */
@@ -591,7 +591,7 @@ public class Zstd {
      *
      * @param src the compressed buffer
      * @param srcPosition offset of the compressed data inside the src buffer
-     * @param srcSize length of the compressed buffer
+     * @param srcSize length of the compressed data inside the src buffer
      * @return the number of bytes of the original buffer
      *         0 if the original size is not known
      */

--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -571,7 +571,7 @@ public class Zstd {
      *
      * @param src the compressed buffer
      * @return the number of bytes of the original buffer
-     *         0 if the original size is now known
+     *         0 if the original size is not known
      */
     public static native long decompressedSize(byte[] src);
 
@@ -579,8 +579,21 @@ public class Zstd {
      * Return the original size of a compressed buffer (if known)
      *
      * @param src the compressed buffer
+     * @param srcPosition offset of the compressed data inside the src buffer
+     * @param srcSize length of the compressed buffer
      * @return the number of bytes of the original buffer
-     *         0 if the original size is now known
+     *         0 if the original size is not known
+     */
+//    public static native long decompressedSize(byte[] src, int srcPosition, int srcSize);
+
+    /**
+     * Return the original size of a compressed buffer (if known)
+     *
+     * @param src the compressed buffer
+     * @param srcPosition offset of the compressed data inside the src buffer
+     * @param srcSize length of the compressed buffer
+     * @return the number of bytes of the original buffer
+     *         0 if the original size is not known
      */
     public static native long decompressedDirectByteBufferSize(ByteBuffer src, int srcPosition, int srcSize);
 

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -110,6 +110,36 @@ class ZstdSpec extends FlatSpec with Checkers {
     }
   }
 
+  it should "support calculating decompressedSize on ByteBuffers which wrap byte[]" in {
+    check { input: Array[Byte] =>
+      val size = input.length
+      val compressed = Zstd.compress(input)
+      val compressedBuffer = ByteBuffer.wrap(compressed)
+      Zstd.decompressedSize(compressedBuffer) == size
+    }
+  }
+
+  it should "support calculating decompressedSize on byte[] via offset" in {
+//    check { input: Array[Byte] =>
+//      val size = input.length
+//      val compressed = Zstd.compress(input)
+//      Zstd.decompressedSize(compressed, 0, compressed.length) == size
+//    }
+    pending
+  }
+
+  it should "support calculating decompressedSize on direct ByteBuffers via an offset" in {
+    check { (before: Array[Byte], input: Array[Byte], after: Array[Byte]) =>
+      val size = input.length
+      val compressed = Zstd.compress(input)
+      val paddedCompressed = before ++ compressed ++ after
+      val paddedCompressedBuffer = ByteBuffer.allocateDirect(paddedCompressed.length)
+      paddedCompressedBuffer.put(paddedCompressed)
+      paddedCompressedBuffer.flip()
+      Zstd.decompressedDirectByteBufferSize(paddedCompressedBuffer, before.length, compressed.length) == size
+    }
+  }
+
   it should s"honor non-zero position and limit values in ByteBuffers" in {
     check { input: Array[Byte] =>
       val size = input.length


### PR DESCRIPTION
Fix a typo on decompressedSize methods

It is currently not possible to calculate decompressedSize on byte[]'s directly if the compressed data is offset.
One needs to allocate a direct ByteBuffer and then copy the byte[] into that buffer to use the decompressedDirectByteBufferSize (the tests shows such an example).

Would it be possible to add a feature which adds an offset/length to the decompressedSize method which operates on byte arrays? I've mocked the method signature to show what I'm thinking of (no need to merge these, really, just made the PR to propose the feature).

I've also added a failing test which demonstrates that it's not possible to work around this by using ByteBuffer.wrap(byte[]),  
one needs to copy the byte[] into a direct ByteBuffer instead (or, of course, work with direct byte buffers entirely)...