### PR TITLE
Reuse internal buffers

### DIFF
--- a/src/main/java/com/github/luben/zstd/BufferPool.java
+++ b/src/main/java/com/github/luben/zstd/BufferPool.java
@@ -1,0 +1,34 @@
+package com.github.luben.zstd;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+/**
+ * An pool of buffers which uses a simple reference queue to recycle old buffers.
+ */
+class BufferPool {
+    private static final Map<Integer, Deque<byte[]>> queues = new HashMap<Integer, Deque<byte[]>>();
+
+    private static synchronized Deque<byte[]> getQueue(int length) {
+        Deque<byte[]> queue = queues.get(length);
+        if (queue == null) {
+            queue = new ArrayDeque<byte[]>();
+            queues.put(length, queue);
+        }
+        return queue;
+    }
+
+    static synchronized byte[] checkOut(int length) {
+        byte[] buffer = getQueue(length).pollFirst();
+        if (buffer == null) {
+            buffer = new byte[length];
+        }
+        return buffer;
+    }
+
+    static synchronized void checkIn(byte[] buffer) {
+        getQueue(buffer.length).addLast(buffer);
+    }
+}

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -57,20 +57,20 @@ public class ZstdOutputStream extends FilterOutputStream {
         Zstd.setCompressionLevel(this.stream, level);
     }
 
-    /* The constuctor */
+    /* The constructor */
     public ZstdOutputStream(OutputStream outStream, int level) throws IOException {
         this(outStream);
         this.closeFrameOnFlush = false;
         Zstd.setCompressionLevel(this.stream, level);
     }
 
-    /* The constuctor */
+    /* The constructor */
     public ZstdOutputStream(OutputStream outStream) throws IOException {
         super(outStream);
         // create compression context
         this.stream = createCStream();
         this.closeFrameOnFlush = false;
-        this.dst = new byte[(int) dstSize];
+        this.dst = BufferPool.checkOut(dstSize);
     }
 
     public synchronized ZstdOutputStream setChecksum(boolean useChecksums) throws IOException {
@@ -232,6 +232,7 @@ public class ZstdOutputStream extends FilterOutputStream {
         } finally {
             // release the resources even if underlying stream throw an exception
             isClosed = true;
+            BufferPool.checkIn(dst);
             freeCStream(stream);
         }
     }

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -843,14 +843,15 @@ class ZstdSpec extends FlatSpec with Checkers {
   }
 
   "BufferPool" should "recycle buffers" in {
-    val largeBuf1 = BufferPool.checkOut(10)
-    val largeBuf2 = BufferPool.checkOut(10)
-    val largeBuf3 = BufferPool.checkOut(10)
-    BufferPool.checkIn(largeBuf1)
-    BufferPool.checkIn(largeBuf2)
-    val largeBuf4 = BufferPool.checkOut(10)
-    val largeBuf5 = BufferPool.checkOut(10)
-    val largeBuf6 = BufferPool.checkOut(10)
+    val pool = BufferPool.get(10)
+    val largeBuf1 = pool.checkOut()
+    val largeBuf2 = pool.checkOut()
+    val largeBuf3 = pool.checkOut()
+    pool.checkIn(largeBuf1)
+    pool.checkIn(largeBuf2)
+    val largeBuf4 = pool.checkOut()
+    val largeBuf5 = pool.checkOut()
+    val largeBuf6 = pool.checkOut()
     assert(largeBuf1 != largeBuf2)
     assert(largeBuf1 != largeBuf3)
     assert(largeBuf2 != largeBuf3)


### PR DESCRIPTION
I added a BufferPool class to allow the library to reuse internal buffers. I had noted that there were a decent amount of large allocations and some GC activity occurring. Since all of these buffers are the same size, it was an ideal candidate for buffer reuse. This should provide some relief in scenarios where maybe a ZstdOutputStream/ZstdInputStream is allocated once per file or connection or other resource in an application (specifically Kafka) and those resources are periodically recycled.

I did choose to remove the ability to pass in the byte[] into the ZstdInputStream, since in that case it would be unclear who owned that byte[]. Also in the discussion of https://github.com/luben/zstd-jni/issues/131 it was made clear that a reuse behavior was desired and could not use any non-Java standard classes. To that end, I decided to drop support for that and hide the reuse logic from the end user. Snappy does allow for customization of the reuse logic, but I'm going to hold off on that unless that is really desired.

I put together a JMH benchmark (note - I did use the netty library in my case, but any outputstream to wrap should work):

````java
ByteBuf buf = PooledByteBufAllocator.DEFAULT.heapBuffer(BUFFER_SIZE);
try (InputStream is = new ByteArrayInputStream(src);
		OutputStream gos = new SnappyOutputStream(new ByteBufOutputStream(buf))) {
	int n;
	while (-1 != (n = is.read(tmp))) {
		gos.write(tmp, 0, n);
	}
} finally {
	buf.release();
}
````

NEW:
````
Benchmark                                                     Mode  Cnt      Score     Error   Units
MyBenchmark.zstdBufferPool                                   thrpt    5  12079.029 ± 975.565   ops/s
MyBenchmark.zstdBufferPool:·gc.alloc.rate                    thrpt    5      1.650 ±   0.137  MB/sec
MyBenchmark.zstdBufferPool:·gc.alloc.rate.norm               thrpt    5    150.404 ±   0.836    B/op
MyBenchmark.zstdBufferPool:·gc.churn.G1_Eden_Space           thrpt    5      1.903 ±   9.456  MB/sec
MyBenchmark.zstdBufferPool:·gc.churn.G1_Eden_Space.norm      thrpt    5    175.388 ± 876.010    B/op
MyBenchmark.zstdBufferPool:·gc.churn.G1_Survivor_Space       thrpt    5      0.133 ±   1.147  MB/sec
MyBenchmark.zstdBufferPool:·gc.churn.G1_Survivor_Space.norm  thrpt    5     12.368 ± 106.492    B/op
MyBenchmark.zstdBufferPool:·gc.count                         thrpt    5      6.000            counts
MyBenchmark.zstdBufferPool:·gc.time                          thrpt    5    215.000                ms
````

OLD:
````
Benchmark                                                       Mode  Cnt       Score       Error   Units
MyBenchmark.zstdBaseline1456                                   thrpt    5    8508.975 ±  1646.953   ops/s
MyBenchmark.zstdBaseline1456:·gc.alloc.rate                    thrpt    5    1017.925 ±   197.283  MB/sec
MyBenchmark.zstdBaseline1456:·gc.alloc.rate.norm               thrpt    5  131750.644 ±     0.850    B/op
MyBenchmark.zstdBaseline1456:·gc.churn.G1_Eden_Space           thrpt    5    1158.503 ±   297.409  MB/sec
MyBenchmark.zstdBaseline1456:·gc.churn.G1_Eden_Space.norm      thrpt    5  149861.671 ± 13690.768    B/op
MyBenchmark.zstdBaseline1456:·gc.churn.G1_Survivor_Space       thrpt    5      51.783 ±    16.397  MB/sec
MyBenchmark.zstdBaseline1456:·gc.churn.G1_Survivor_Space.norm  thrpt    5    6699.395 ±  1456.076    B/op
MyBenchmark.zstdBaseline1456:·gc.count                         thrpt    5     175.000              counts
MyBenchmark.zstdBaseline1456:·gc.time                          thrpt    5    9065.000                  ms
````

As expected, there is a great improvement in `gc.alloc.rate.norm` (allocation's per operation) and quantity/length of GC pauses. And obviously this all leads to the throughput in ops/s to increase.