### PR TITLE
Allow users to pass in a BufferPool implementation

### DIFF
--- a/src/main/java/com/github/luben/zstd/RecyclingBufferPool.java
+++ b/src/main/java/com/github/luben/zstd/RecyclingBufferPool.java
@@ -1,0 +1,46 @@
+package com.github.luben.zstd;
+
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+/**
+ * An pool of buffers which uses a simple reference queue to recycle old buffers.
+ */
+public class RecyclingBufferPool implements BufferPool {
+    public static final BufferPool INSTANCE = new RecyclingBufferPool();
+
+    private final Map<Integer, SoftReference<Deque<ByteBuffer>>> pools;
+    
+    private RecyclingBufferPool() {
+        this.pools = new HashMap<Integer, SoftReference<Deque<ByteBuffer>>>();
+    }
+
+    private Deque<ByteBuffer> getDeque(int capacity) {
+        SoftReference<Deque<ByteBuffer>> dequeReference = pools.get(capacity);
+        Deque<ByteBuffer> deque;
+        if (dequeReference == null || (deque = dequeReference.get()) == null) {
+            deque = new ArrayDeque<ByteBuffer>();
+            dequeReference = new SoftReference<Deque<ByteBuffer>>(deque);
+            pools.put(capacity, dequeReference);
+        }
+        return deque;
+    }
+
+    @Override
+    public synchronized ByteBuffer get(int capacity) {
+        ByteBuffer buffer = getDeque(capacity).pollFirst();
+        if (buffer == null) {
+            buffer = ByteBuffer.allocate(capacity);
+        }
+        return buffer;
+    }
+
+    @Override
+    public synchronized void release(ByteBuffer buffer) {
+        getDeque(buffer.capacity()).addLast(buffer);
+    }
+}

--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -1272,4 +1272,11 @@ public class Zstd {
             ctx.close();
         }
     }
+
+    static final byte[] extractArray(ByteBuffer buffer) {
+        if (!buffer.hasArray() || buffer.arrayOffset() != 0) {
+            throw new IllegalArgumentException("provided ByteBuffer lacks array or has non-zero arrayOffset");
+        }
+        return buffer.array();
+    }
 }


### PR DESCRIPTION
I added a new interface to represent a BufferPool. I added some constructor arguments to allow users to pass in their implementation (like Snappy does).

For kafka, it should be very simple to make a shim that wraps their BufferSupplier https://github.com/apache/kafka/blob/b6ce9d68627bda904924ba2dce5c334a2c615e18/clients/src/main/java/org/apache/kafka/common/record/BufferSupplier.java
That was one of the main reasons I chose to use ByteBuffer rather than byte[]. I do the same check to make sure the ByteBuffers are properly able to be used: https://github.com/apache/kafka/blob/b6ce9d68627bda904924ba2dce5c334a2c615e18/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockInputStream.java#L80