### PR TITLE
Add `Zstd.decompressedSize(src, offset, limit)`

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -571,10 +571,23 @@ public class Zstd {
      *
      * @param src the compressed buffer
      * @param srcPosition offset of the compressed data inside the src buffer
+     * @param srcSize length of the compressed data inside the src buffer
      * @return the number of bytes of the original buffer
      *         0 if the original size is not known
      */
-    public static native long decompressedSize(byte[] src, int srcPosition);
+    public static native long decompressedSize(byte[] src, int srcPosition, int srcSize);
+
+    /**
+     * Return the original size of a compressed buffer (if known)
+     *
+     * @param src the compressed buffer
+     * @param srcPosition offset of the compressed data inside the src buffer
+     * @return the number of bytes of the original buffer
+     *         0 if the original size is not known
+     */
+    public static long decompressedSize(byte[] src, int srcPosition) {
+        return decompressedSize(src, srcPosition, src.length - srcPosition);
+    }
 
     /**
      * Return the original size of a compressed buffer (if known)

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -45,15 +45,14 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressUnsafe
 /*
  * Class:     com_github_luben_zstd_Zstd
  * Method:    decompressedSize
- * Signature: ([B)JI
+ * Signature: ([B)JII
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressedSize
-  (JNIEnv *env, jclass obj, jbyteArray src, jint offset) {
+  (JNIEnv *env, jclass obj, jbyteArray src, jint offset, jint limit) {
     size_t size = (size_t)(0-ZSTD_error_memory_allocation);
-    jsize src_size = (*env)->GetArrayLength(env, src);
     void *src_buff = (*env)->GetPrimitiveArrayCritical(env, src, NULL);
     if (src_buff == NULL) goto E1;
-    size = ZSTD_getDecompressedSize(((char *) src_buff) + offset, (size_t) src_size - offset);
+    size = ZSTD_getDecompressedSize(((char *) src_buff) + offset, (size_t) limit);
     (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
 E1: return size;
 }


### PR DESCRIPTION
Continuation of #133

Methods operating on `byte[]` are much more useful when `offset` is paired with `limit`, this allows to constrict the frame length that ZSTD native will use when calculating the decompressed size

TODO: The official docs recommend moving towards `ZSTD_getFrameContentSize` as it differentiates between various reasons why the decompressed size may not be available, while current implementation flattens them into 0