### PR TITLE
Add a GitHub Action to build and test under qemu s390x emulation

### DIFF
--- a/.github/actions/qemu-cross/action.yml
+++ b/.github/actions/qemu-cross/action.yml
@@ -1,0 +1,14 @@
+name: 'QEMU Cross'
+description: 'Compile and test under QEMU'
+inputs:
+  platform:
+    description: 'qemu guest os'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: ${{ github.action_path }}/docker.sh
+      shell: bash
+      env:
+        PLATFORM_NAME: ${{ inputs.platform }}
+        HOST_WORKSPACE_DIR: ${{ github.workspace }}

--- a/.github/actions/qemu-cross/build.sh
+++ b/.github/actions/qemu-cross/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+apt-get update
+apt-get install -y gcc
+./sbt -v test package

--- a/.github/actions/qemu-cross/build.sh
+++ b/.github/actions/qemu-cross/build.sh
@@ -4,4 +4,11 @@ set -e
 
 apt-get update
 apt-get install -y gcc
-./sbt -v test package
+
+SBT_CMD="test"
+# On big endian platforms, exclude some tests that are affected by
+# https://github.com/facebook/zstd/issues/2736 in zstd 1.5.0.
+if [[ $(uname -m) == "s390x" ]]; then
+  SBT_CMD="testOnly * -- -l ZstdIssue2736"
+fi
+./sbt -v "${SBT_CMD}"

--- a/.github/actions/qemu-cross/docker.sh
+++ b/.github/actions/qemu-cross/docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+docker run --rm \
+    --platform ${PLATFORM_NAME} \
+    --name qemu-cross-${PLATFORM_NAME} \
+    --mount type=bind,source=${HOST_WORKSPACE_DIR},target=/github_workspace \
+    --workdir /github_workspace \
+    ${PLATFORM_NAME}/eclipse-temurin:11-jdk-focal ./.github/actions/qemu-cross/build.sh

--- a/.github/workflows/ci-qemu-cross.yml
+++ b/.github/workflows/ci-qemu-cross.yml
@@ -1,0 +1,18 @@
+name: "CI qemu cross"
+on: [push, pull_request]
+jobs:
+    qemu-cross:
+        strategy:
+            matrix:
+                include: [
+                    { platform: s390x }
+                ]
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - uses: docker/setup-qemu-action@v1
+
+        - name: qemu ${{ matrix.platform }} build and test
+          uses: ./.github/actions/qemu-cross
+          with:
+            platform: ${{ matrix.platform }}

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -1,6 +1,6 @@
 package com.github.luben.zstd
 
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, Tag}
 import org.scalatest.prop.Checkers
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop._
@@ -12,6 +12,15 @@ import java.nio.file.StandardOpenOption
 
 import scala.io._
 import scala.collection.mutable.WrappedArray
+
+// zstd 1.5.0 does not produce idential compressed files on big endian and little endian platforms.
+// This is not a bug because it is not guaranteed and does not cause incorrect behavior but
+// all previous zstd versions do produce identical compressed files.
+// The zstd dev branch has changes that restore the previous behavior and the next release will
+// produce idential files so tag the affected tests for now so they can be excluded on
+// big endian platforms until the next zstd release.
+// See https://github.com/facebook/zstd/issues/2736
+object ZstdIssue2736 extends Tag("ZstdIssue2736")
 
 class ZstdSpec extends FlatSpec with Checkers {
 
@@ -703,7 +712,7 @@ class ZstdSpec extends FlatSpec with Checkers {
   }
 
   for (level <- levels)
-    "ZstdOutputStream" should s"produce the same compressed file as zstd binary at level $level" in {
+    "ZstdOutputStream" should s"produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val fis  = new FileInputStream(file)
@@ -728,7 +737,7 @@ class ZstdSpec extends FlatSpec with Checkers {
     }
 
   for (level <- levels)
-    "ZstdDirectBufferCompressingStream" should s"produce the same compressed file as zstd binary at level $level" in {
+    "ZstdDirectBufferCompressingStream" should s"produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val channel = FileChannel.open(file.toPath, StandardOpenOption.READ)
@@ -751,7 +760,7 @@ class ZstdSpec extends FlatSpec with Checkers {
     }
 
   for (level <- levels)
-    "ZstdDirectBufferCompressingStream" should s" even when writing one byte at a time produce the same compressed file as zstd binary at level $level" in {
+    "ZstdDirectBufferCompressingStream" should s" even when writing one byte at a time produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val channel = FileChannel.open(file.toPath, StandardOpenOption.READ)


### PR DESCRIPTION
This PR adds support for building and testing zstd-jni under qemu s390x emulation.

The goal of this PR is to help catch any potential issues early on platforms not currently natively supported on GitHub Actions. I've been doing some work recently testing zstd-jni on s390x and thought it might be useful to contribute these changes.

The new action sets up qemu on the runner and runs a custom step that runs an s390x docker container under qemu which is used to build and test with sbt. It should be easy to add other platforms as well but I have not tried that.

Some tests needed to be disabled for 1.5.0. See comments in the changes to src/test/scala/Zstd.scala. Happy to provide more detail if needed.

Building and testing under qemu is slower than native so not sure if the action should be run on `[push, pull_request]` but I left it that way to start.

Happy to discuss this PR. Looking forward to any feedback.