### PR TITLE
Expose the default compression level

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -757,6 +757,7 @@ public class Zstd {
     public static native int frameHeaderSizeMin();
     public static native int frameHeaderSizeMax();
     public static native int blockSizeMax();
+    public static native int defaultCompressionLevel();
     /* Min/max compression levels */
     public static native int minCompressionLevel();
     public static native int maxCompressionLevel();
@@ -772,7 +773,7 @@ public class Zstd {
      * @return byte array with the compressed data
      */
     public static byte[] compress(byte[] src) throws ZstdException {
-        return compress(src, 3);
+        return compress(src, defaultCompressionLevel());
     }
 
     /**
@@ -811,7 +812,7 @@ public class Zstd {
      */
 
     public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf) throws ZstdException {
-        return compress(dstBuf, srcBuf, 3);
+        return compress(dstBuf, srcBuf, defaultCompressionLevel());
     }
 
     /**

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -41,7 +41,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
 
     /**
      * Set compression level
-     * @param level compression level, default: 3
+     * @param level compression level, default: {@link Zstd#defaultCompressionLevel()}
      */
     public ZstdCompressCtx setLevel(int level) {
         if (nativePtr == 0) {

--- a/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
@@ -9,7 +9,7 @@ public class ZstdDictCompress extends SharedDictBase {
     }
 
     private long nativePtr = 0;
-    private int level = 3;
+    private int level = Zstd.defaultCompressionLevel();
 
     private native void init(byte[] dict, int dict_offset, int dict_size, int level);
 

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
@@ -44,7 +44,7 @@ public class ZstdDirectBufferCompressingStream implements Closeable, Flushable {
     private boolean closed = false;
     private boolean initialized = false;
     private boolean finalize = true;
-    private int level = 3;
+    private int level = Zstd.defaultCompressionLevel();
     private byte[] dict = null;
     private ZstdDictCompress fastDict = null;
 

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -108,7 +108,7 @@ public class ZstdOutputStream extends FilterOutputStream{
     /**
      * Set the compression level.
      *
-     * Default: 3
+     * Default: {@link Zstd#defaultCompressionLevel()}
      */
     public ZstdOutputStream setLevel(int level) throws IOException {
         inner.setLevel(level);

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
@@ -105,7 +105,7 @@ public class ZstdOutputStreamNoFinalizer extends FilterOutputStream {
     /**
      * Set the compression level.
      *
-     * Default: 3
+     * Default: {@link Zstd#defaultCompressionLevel()}
      */
     public synchronized ZstdOutputStreamNoFinalizer setLevel(int level) throws IOException {
         if (!frameClosed) {

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -338,6 +338,11 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_blockSizeMax
     return ZSTD_BLOCKSIZE_MAX;
 }
 
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_defaultCompressionLevel
+  (JNIEnv *env, jclass obj) {
+    return ZSTD_CLEVEL_DEFAULT;
+}
+
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_minCompressionLevel
   (JNIEnv *env, jclass obj) {
     return ZSTD_minCLevel();

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -34,6 +34,7 @@ class ZstdSpec extends FlatSpec with Checkers {
       check { input: Array[Byte] =>
         {
           val size        = input.length
+          // Assumes that `Zstd.defaultCompressionLevel() == 3`.
           val compressed  = if (level != 3) Zstd.compress(input, level) else Zstd.compress(input)
           val decompressed= Zstd.decompress(compressed, size)
           input.toSeq == decompressed.toSeq && size == Zstd.decompressedSize(compressed)
@@ -66,6 +67,7 @@ class ZstdSpec extends FlatSpec with Checkers {
           inputBuffer.put(input)
           inputBuffer.flip()
           val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size).toInt)
+          // Assumes that `Zstd.defaultCompressionLevel() == 3`.
           val compressedSize = if (level != 3)
             Zstd.compress(compressedBuffer, inputBuffer, level)
           else


### PR DESCRIPTION
Introduces `Zstd.defaultCompressionLevel()` in favour of hard-coding the value 3 in several places.