### PR TITLE
No longer skip tests on s390x platform since resolved with zstd 1.5.1

### DIFF
--- a/.github/actions/qemu-cross/build.sh
+++ b/.github/actions/qemu-cross/build.sh
@@ -6,9 +6,4 @@ apt-get update
 apt-get install -y gcc
 
 SBT_CMD="test"
-# On big endian platforms, exclude some tests that are affected by
-# https://github.com/facebook/zstd/issues/2736 in zstd 1.5.0.
-if [[ $(uname -m) == "s390x" ]]; then
-  SBT_CMD="testOnly * -- -l ZstdIssue2736"
-fi
 ./sbt -v "${SBT_CMD}"

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -13,15 +13,6 @@ import java.nio.file.StandardOpenOption
 import scala.io._
 import scala.collection.mutable.WrappedArray
 
-// zstd 1.5.0 does not produce idential compressed files on big endian and little endian platforms.
-// This is not a bug because it is not guaranteed and does not cause incorrect behavior but
-// all previous zstd versions do produce identical compressed files.
-// The zstd dev branch has changes that restore the previous behavior and the next release will
-// produce idential files so tag the affected tests for now so they can be excluded on
-// big endian platforms until the next zstd release.
-// See https://github.com/facebook/zstd/issues/2736
-object ZstdIssue2736 extends Tag("ZstdIssue2736")
-
 class ZstdSpec extends FlatSpec with Checkers {
 
   implicit override val generatorDrivenConfig =
@@ -714,7 +705,7 @@ class ZstdSpec extends FlatSpec with Checkers {
   }
 
   for (level <- levels)
-    "ZstdOutputStream" should s"produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
+    "ZstdOutputStream" should s"produce the same compressed file as zstd binary at level $level" in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val fis  = new FileInputStream(file)
@@ -739,7 +730,7 @@ class ZstdSpec extends FlatSpec with Checkers {
     }
 
   for (level <- levels)
-    "ZstdDirectBufferCompressingStream" should s"produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
+    "ZstdDirectBufferCompressingStream" should s"produce the same compressed file as zstd binary at level $level" in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val channel = FileChannel.open(file.toPath, StandardOpenOption.READ)
@@ -762,7 +753,7 @@ class ZstdSpec extends FlatSpec with Checkers {
     }
 
   for (level <- levels)
-    "ZstdDirectBufferCompressingStream" should s" even when writing one byte at a time produce the same compressed file as zstd binary at level $level" taggedAs ZstdIssue2736 in {
+    "ZstdDirectBufferCompressingStream" should s" even when writing one byte at a time produce the same compressed file as zstd binary at level $level" in {
       val file = new File("src/test/resources/xml")
       val length = file.length.toInt
       val channel = FileChannel.open(file.toPath, StandardOpenOption.READ)


### PR DESCRIPTION
Remove the tag on some tests that was added for
https://github.com/facebook/zstd/issues/2736 on big endian platforms now
that the issue is resolved in zstd 1.5.1.

Update CI so that all tests are run on s390x.