### PR TITLE
Add NoFinalizer variants for the direct buffer streams.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,8 +42,8 @@ jniNativeClasses := Seq(
   "com.github.luben.zstd.ZstdDictDecompress",
   "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
   "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
-  "com.github.luben.zstd.ZstdDirectBufferDecompressingStream",
-  "com.github.luben.zstd.ZstdDirectBufferCompressingStream"
+  "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer",
+  "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
 )
 
 jniLibSuffix := (System.getProperty("os.name").toLowerCase match {

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStream.java
@@ -13,8 +13,8 @@ public class ZstdDirectBufferCompressingStream implements Closeable, Flushable {
         Native.load();
     }
 
-    private ByteBuffer target;
-    private final long stream;
+    ZstdDirectBufferCompressingStreamNoFinalizer inner;
+    private boolean finalize;
 
     /**
      * This method should flush the buffer and either return the same buffer (but cleared) or a new buffer
@@ -27,53 +27,23 @@ public class ZstdDirectBufferCompressingStream implements Closeable, Flushable {
     }
 
     public ZstdDirectBufferCompressingStream(ByteBuffer target, int level) throws IOException {
-        if (!target.isDirect()) {
-            throw new IllegalArgumentException("Target buffer should be a direct buffer");
-        }
-        synchronized(this) {
-            this.target = target;
-            this.level = level;
-            stream = createCStream();
-        }
+        inner = new ZstdDirectBufferCompressingStreamNoFinalizer(target, level) {
+                @Override
+                protected ByteBuffer flushBuffer(ByteBuffer toFlush) throws IOException {
+                    return ZstdDirectBufferCompressingStream.this.flushBuffer(toFlush);
+                }
+            };
     }
 
-    public static int recommendedOutputBufferSize() { return (int)recommendedCOutSize(); }
-
-    private int consumed = 0;
-    private int produced = 0;
-    private boolean closed = false;
-    private boolean initialized = false;
-    private boolean finalize = true;
-    private int level = Zstd.defaultCompressionLevel();
-    private byte[] dict = null;
-    private ZstdDictCompress fastDict = null;
-
-    /* JNI methods */
-    private static native long recommendedCOutSize();
-    private static native long createCStream();
-    private static native int  freeCStream(long ctx);
-    private native int  initCStream(long ctx, int level);
-    private native int  initCStreamWithDict(long ctx, byte[] dict, int dict_size, int level);
-    private native int  initCStreamWithFastDict(long ctx, ZstdDictCompress dict);
-    private native int  compressDirectByteBuffer(long ctx, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
-    private native int  flushStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
-    private native int  endStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
+    public static int recommendedOutputBufferSize() { return ZstdDirectBufferCompressingStreamNoFinalizer.recommendedOutputBufferSize(); }
 
     public synchronized ZstdDirectBufferCompressingStream setDict(byte[] dict) throws IOException {
-        if (initialized) {
-            throw new IOException("Change of parameter on initialized stream");
-        }
-        this.dict = dict;
-        this.fastDict = null;
+        inner.setDict(dict);
         return this;
     }
 
     public synchronized ZstdDirectBufferCompressingStream setDict(ZstdDictCompress dict) throws IOException {
-        if (initialized) {
-            throw new IOException("Change of parameter on initialized stream");
-        }
-        this.dict = null;
-        this.fastDict = dict;
+        inner.setDict(dict);
         return this;
     }
 
@@ -89,106 +59,17 @@ public class ZstdDirectBufferCompressingStream implements Closeable, Flushable {
     }
 
     public synchronized void compress(ByteBuffer source) throws IOException {
-        if (!source.isDirect()) {
-            throw new IllegalArgumentException("Source buffer should be a direct buffer");
-        }
-        if (closed) {
-            throw new IOException("Stream closed");
-        }
-        if (!initialized) {
-            int result = 0;
-            ZstdDictCompress fastDict = this.fastDict;
-            if (fastDict != null) {
-                fastDict.acquireSharedLock();
-                try {
-                    result = initCStreamWithFastDict(stream, fastDict);
-                } finally {
-                    fastDict.releaseSharedLock();
-                }
-            } else if (dict != null) {
-                result = initCStreamWithDict(stream, dict, dict.length, level);
-            } else {
-                result = initCStream(stream, level);
-            }
-            if (Zstd.isError(result)) {
-                throw new IOException("Compression error: cannot create header: " + Zstd.getErrorName(result));
-            }
-            initialized = true;
-        }
-        while (source.hasRemaining()) {
-            if (!target.hasRemaining()) {
-                target = flushBuffer(target);
-                if (!target.isDirect()) {
-                    throw new IllegalArgumentException("Target buffer should be a direct buffer");
-                }
-                if (!target.hasRemaining()) {
-                    throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
-                }
-            }
-            int result = compressDirectByteBuffer(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
-            if (Zstd.isError(result)) {
-                throw new IOException("Compression error: " + Zstd.getErrorName(result));
-            }
-            target.position(target.position() + produced);
-            source.position(source.position() + consumed);
-        }
+        inner.compress(source);
     }
 
     @Override
     public synchronized void flush() throws IOException {
-        if (closed) {
-            throw new IOException("Already closed");
-        }
-        if (initialized) {
-            int needed;
-            do {
-                needed = flushStream(stream, target, target.position(), target.remaining());
-                if (Zstd.isError(needed)) {
-                    throw new IOException("Compression error: " + Zstd.getErrorName(needed));
-                }
-                target.position(target.position() + produced);
-                target = flushBuffer(target);
-                if (!target.isDirect()) {
-                    throw new IllegalArgumentException("Target buffer should be a direct buffer");
-                }
-                if (needed > 0 && !target.hasRemaining()) {
-                    // don't check on the first iteration of the loop
-                    throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
-                }
-            }
-            while (needed > 0);
-        }
+        inner.flush();
     }
 
     @Override
     public synchronized void close() throws IOException {
-        if (!closed) {
-            try {
-                if (initialized) {
-                    int needed;
-                    do {
-                        needed = endStream(stream, target, target.position(), target.remaining());
-                        if (Zstd.isError(needed)) {
-                            throw new IOException("Compression error: " + Zstd.getErrorName(needed));
-                        }
-                        target.position(target.position() + produced);
-                        target = flushBuffer(target);
-                        if (!target.isDirect()) {
-                            throw new IllegalArgumentException("Target buffer should be a direct buffer");
-                        }
-                        if (needed > 0 && !target.hasRemaining()) {
-                            throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
-                        }
-                    } while (needed > 0);
-                }
-            }
-            finally {
-                freeCStream(stream);
-                closed = true;
-                initialized = false;
-                target = null; // help GC with realizing the buffer can be released
-            }
-        }
+        inner.close();
     }
 
     @Override

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
@@ -1,0 +1,179 @@
+package com.github.luben.zstd;
+
+import com.github.luben.zstd.util.Native;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, Flushable {
+
+    static {
+        Native.load();
+    }
+
+    private ByteBuffer target;
+    private final long stream;
+
+    /**
+     * This method should flush the buffer and either return the same buffer (but cleared) or a new buffer
+     * that should be used from then on.
+     * @param toFlush buffer that has to be flushed (or most cases, you want to call {@link ByteBuffer#flip()} first)
+     * @return the new buffer to use, for most cases the same as the one passed in, after a call to {@link ByteBuffer#clear()}.
+     */
+    protected ByteBuffer flushBuffer(ByteBuffer toFlush) throws IOException {
+        return toFlush;
+    }
+
+    public ZstdDirectBufferCompressingStreamNoFinalizer(ByteBuffer target, int level) throws IOException {
+        if (!target.isDirect()) {
+            throw new IllegalArgumentException("Target buffer should be a direct buffer");
+        }
+        this.target = target;
+        this.level = level;
+        stream = createCStream();
+    }
+
+    public static int recommendedOutputBufferSize() { return (int)recommendedCOutSize(); }
+
+    private int consumed = 0;
+    private int produced = 0;
+    private boolean closed = false;
+    private boolean initialized = false;
+    private int level = Zstd.defaultCompressionLevel();
+    private byte[] dict = null;
+    private ZstdDictCompress fastDict = null;
+
+    /* JNI methods */
+    private static native long recommendedCOutSize();
+    private static native long createCStream();
+    private static native int  freeCStream(long ctx);
+    private native int  initCStream(long ctx, int level);
+    private native int  initCStreamWithDict(long ctx, byte[] dict, int dict_size, int level);
+    private native int  initCStreamWithFastDict(long ctx, ZstdDictCompress dict);
+    private native int  compressDirectByteBuffer(long ctx, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private native int  flushStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
+    private native int  endStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
+
+    public ZstdDirectBufferCompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
+        if (initialized) {
+            throw new IOException("Change of parameter on initialized stream");
+        }
+        this.dict = dict;
+        this.fastDict = null;
+        return this;
+    }
+
+    public ZstdDirectBufferCompressingStreamNoFinalizer setDict(ZstdDictCompress dict) throws IOException {
+        if (initialized) {
+            throw new IOException("Change of parameter on initialized stream");
+        }
+        this.dict = null;
+        this.fastDict = dict;
+        return this;
+    }
+
+    public void compress(ByteBuffer source) throws IOException {
+        if (!source.isDirect()) {
+            throw new IllegalArgumentException("Source buffer should be a direct buffer");
+        }
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+        if (!initialized) {
+            int result = 0;
+            ZstdDictCompress fastDict = this.fastDict;
+            if (fastDict != null) {
+                fastDict.acquireSharedLock();
+                try {
+                    result = initCStreamWithFastDict(stream, fastDict);
+                } finally {
+                    fastDict.releaseSharedLock();
+                }
+            } else if (dict != null) {
+                result = initCStreamWithDict(stream, dict, dict.length, level);
+            } else {
+                result = initCStream(stream, level);
+            }
+            if (Zstd.isError(result)) {
+                throw new IOException("Compression error: cannot create header: " + Zstd.getErrorName(result));
+            }
+            initialized = true;
+        }
+        while (source.hasRemaining()) {
+            if (!target.hasRemaining()) {
+                target = flushBuffer(target);
+                if (!target.isDirect()) {
+                    throw new IllegalArgumentException("Target buffer should be a direct buffer");
+                }
+                if (!target.hasRemaining()) {
+                    throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
+                }
+            }
+            int result = compressDirectByteBuffer(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
+            if (Zstd.isError(result)) {
+                throw new IOException("Compression error: " + Zstd.getErrorName(result));
+            }
+            target.position(target.position() + produced);
+            source.position(source.position() + consumed);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (closed) {
+            throw new IOException("Already closed");
+        }
+        if (initialized) {
+            int needed;
+            do {
+                needed = flushStream(stream, target, target.position(), target.remaining());
+                if (Zstd.isError(needed)) {
+                    throw new IOException("Compression error: " + Zstd.getErrorName(needed));
+                }
+                target.position(target.position() + produced);
+                target = flushBuffer(target);
+                if (!target.isDirect()) {
+                    throw new IllegalArgumentException("Target buffer should be a direct buffer");
+                }
+                if (needed > 0 && !target.hasRemaining()) {
+                    // don't check on the first iteration of the loop
+                    throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
+                }
+            }
+            while (needed > 0);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!closed) {
+            try {
+                if (initialized) {
+                    int needed;
+                    do {
+                        needed = endStream(stream, target, target.position(), target.remaining());
+                        if (Zstd.isError(needed)) {
+                            throw new IOException("Compression error: " + Zstd.getErrorName(needed));
+                        }
+                        target.position(target.position() + produced);
+                        target = flushBuffer(target);
+                        if (!target.isDirect()) {
+                            throw new IllegalArgumentException("Target buffer should be a direct buffer");
+                        }
+                        if (needed > 0 && !target.hasRemaining()) {
+                            throw new IOException("The target buffer has no more space, even after flushing, and there are still bytes to compress");
+                        }
+                    } while (needed > 0);
+                }
+            }
+            finally {
+                freeCStream(stream);
+                closed = true;
+                initialized = false;
+                target = null; // help GC with realizing the buffer can be released
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
@@ -1,0 +1,124 @@
+package com.github.luben.zstd;
+
+import com.github.luben.zstd.util.Native;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable {
+
+    static {
+        Native.load();
+    }
+
+    /**
+     * Override this method in case the byte buffer passed to the constructor might not contain the full compressed stream
+     * @param toRefill current buffer
+     * @return either the current buffer (but refilled and flipped if there was new content) or a new buffer.
+     */
+    protected ByteBuffer refill(ByteBuffer toRefill) {
+        return toRefill;
+    }
+
+    private ByteBuffer source;
+    private final long stream;
+    private boolean finishedFrame = false;
+    private boolean closed = false;
+    private boolean streamEnd = false;
+
+    private static native int recommendedDOutSize();
+    private static native long createDStream();
+    private static native int  freeDStream(long stream);
+    private native int initDStream(long stream);
+    private native long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+
+    public ZstdDirectBufferDecompressingStreamNoFinalizer(ByteBuffer source) {
+        if (!source.isDirect()) {
+            throw new IllegalArgumentException("Source buffer should be a direct buffer");
+        }
+        this.source = source;
+        stream = createDStream();
+        initDStream(stream);
+    }
+
+    public boolean hasRemaining() {
+        return !streamEnd && (source.hasRemaining() || !finishedFrame);
+    }
+
+    public static int recommendedTargetBufferSize() {
+        return (int) recommendedDOutSize();
+    }
+
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
+        int size = Zstd.loadDictDecompress(stream, dict, dict.length);
+        if (Zstd.isError(size)) {
+            throw new IOException("Decompression error: " + Zstd.getErrorName(size));
+        }
+        return this;
+    }
+
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
+        dict.acquireSharedLock();
+        try {
+            int size = Zstd.loadFastDictDecompress(stream, dict);
+            if (Zstd.isError(size)) {
+                throw new IOException("Decompression error: " + Zstd.getErrorName(size));
+            }
+        } finally {
+            dict.releaseSharedLock();
+        }
+        return this;
+    }
+
+    private int consumed;
+    private int produced;
+    public int read(ByteBuffer target) throws IOException {
+        if (!target.isDirect()) {
+            throw new IllegalArgumentException("Target buffer should be a direct buffer");
+        }
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+        if (streamEnd) {
+            return 0;
+        }
+
+        long remaining = decompressStream(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
+        if (Zstd.isError(remaining)) {
+            throw new IOException(Zstd.getErrorName(remaining));
+        }
+
+        source.position(source.position() + consumed);
+        target.position(target.position() + produced);
+
+        if (!source.hasRemaining()) {
+            source = refill(source);
+            if (!source.isDirect()) {
+                throw new IllegalArgumentException("Source buffer should be a direct buffer");
+            }
+        }
+
+        finishedFrame = remaining == 0;
+        if (finishedFrame) {
+            // nothing left, so at end of the stream
+            streamEnd = !source.hasRemaining();
+        }
+
+        return produced;
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        if (!closed) {
+            try {
+                freeDStream(stream);
+            }
+            finally {
+                closed = true;
+                source = null; // help GC with realizing the buffer can be released
+            }
+        }
+    }
+}

--- a/src/main/native/jni_directbuffercompress_zstd.c
+++ b/src/main/native/jni_directbuffercompress_zstd.c
@@ -9,41 +9,41 @@ static jfieldID consumed_id;
 static jfieldID produced_id;
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    recommendedCOutSize
  * Signature: ()I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_recommendedCOutSize
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_recommendedCOutSize
   (JNIEnv *env, jclass obj) {
     return (jint) ZSTD_CStreamOutSize();
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    createCStream
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_createCStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_createCStream
   (JNIEnv *env, jclass obj) {
     return (jlong)(intptr_t) ZSTD_createCStream();
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    freeCStream
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_freeCStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_freeCStream
   (JNIEnv *env, jclass obj, jlong stream) {
     return ZSTD_freeCStream((ZSTD_CStream *)(intptr_t) stream);
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    initCStream
  * Signature: (JI)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_initCStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStream
   (JNIEnv *env, jclass obj, jlong stream, jint level) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
@@ -52,11 +52,11 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStr
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    initCStreamWithDict
  * Signature: (J[BII)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_initCStreamWithDict
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStreamWithDict
   (JNIEnv *env, jclass obj, jlong stream, jbyteArray dict, jint dict_size, jint level) {
     size_t result = (size_t)(0-ZSTD_error_memory_allocation);
     jclass clazz = (*env)->GetObjectClass(env, obj);
@@ -73,10 +73,10 @@ E1:
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    initCStreamWithFastDict
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_initCStreamWithFastDict
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStreamWithFastDict
   (JNIEnv *env, jclass obj, jlong stream, jobject dict) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
@@ -90,11 +90,11 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStr
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    compressDirectByteBuffer
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_compressDirectByteBuffer
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_compressDirectByteBuffer
   (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
 
     size_t size = (size_t)ERROR(memory_allocation);
@@ -118,11 +118,11 @@ E1: return size;
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    endStream
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_endStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_endStream
   (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size) {
 
     size_t size = (size_t)(0-ZSTD_error_memory_allocation);
@@ -140,11 +140,11 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStr
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer
  * Method:    flushStream
  * Signature: (JLjava/nio/ByteBuffer;II)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStream_flushStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_flushStream
   (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size) {
 
     size_t size = (size_t)(0-ZSTD_error_memory_allocation);

--- a/src/main/native/jni_directbufferdecompress_zstd.c
+++ b/src/main/native/jni_directbufferdecompress_zstd.c
@@ -9,41 +9,41 @@ static jfieldID consumed_id;
 static jfieldID produced_id;
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
  * Method:    recommendedDOutSize
  * Signature: ()I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStream_recommendedDOutSize
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_recommendedDOutSize
   (JNIEnv *env, jclass obj) {
     return (jint) ZSTD_DStreamOutSize();
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
  * Method:    createDStream
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStream_createDStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_createDStream
   (JNIEnv *env, jclass obj) {
     return (jlong)(intptr_t) ZSTD_createDStream();
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
  * Method:    freeDStream
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStream_freeDStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_freeDStream
   (JNIEnv *env, jclass obj, jlong stream) {
     return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
  * Method:    initDStream
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStream_initDStream
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_initDStream
   (JNIEnv *env, jclass obj, jlong stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
@@ -52,11 +52,11 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingS
 }
 
 /*
- * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStream
+ * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
  * Method:    decompressStream
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)I
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStream_decompressStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_decompressStream
   (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
     size_t size = (size_t)ERROR(memory_allocation);
 


### PR DESCRIPTION
Following the pattern set by ZstdInputStreamNoFinalizer and ZstdOutputStreamNoFinalizer, add NoFinalizer variants for the direct buffer compressing and decompressing streams. The original classes with finalizers are reimplemented as simple wrappers over the NoFinalizer variants.

https://github.com/luben/zstd-jni/issues/83
