### PR TITLE
Add methods for streaming (de)compression of direct ByteBuffers.

### DIFF
--- a/src/main/java/com/github/luben/zstd/EndDirective.java
+++ b/src/main/java/com/github/luben/zstd/EndDirective.java
@@ -1,0 +1,20 @@
+package com.github.luben.zstd;
+
+/** Enum that expresses desired flushing for a streaming compression call.
+ *
+ * @see ZstdCompressCtx#compressDirectByteBufferStream
+ */
+public enum EndDirective {
+    CONTINUE(0),
+    FLUSH(1),
+    END(2);
+
+    private final int value;
+    private EndDirective(int value) {
+        this.value = value;
+    }
+
+    int value() {
+        return value;
+    }
+}


### PR DESCRIPTION
The goal of this change is to enable the highest-performance (de)compression of streams. `ZSTD_compressStream2` and `ZSTD_decompressStream` are exposed on `ZstdCompressCtx` and `ZstdDecompressCtx` respectively. They work in terms of direct `ByteBuffer`s and allow non-blocking, incremental handling of streams. The new `reset()` methods on `ZstdCompressCtx` and `ZstdDecompressCtx` allow reusing contexts, avoiding unnecessary allocations and deallocations.
