### PR TITLE
Throw ZstdException when the error is coming from Zstd

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -770,7 +770,7 @@ public class Zstd {
      * @param src the source buffer
      * @return byte array with the compressed data
      */
-    public static byte[] compress(byte[] src) throws ZstdException {
+    public static byte[] compress(byte[] src) {
         return compress(src, defaultCompressionLevel());
     }
 
@@ -781,7 +781,7 @@ public class Zstd {
      * @param level compression level
      * @return byte array with the compressed data
      */
-    public static byte[] compress(byte[] src, int level) throws ZstdException {
+    public static byte[] compress(byte[] src, int level) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.setLevel(level);
@@ -809,7 +809,7 @@ public class Zstd {
      * @return the size of the compressed data
      */
 
-    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf) throws ZstdException {
+    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf) {
         return compress(dstBuf, srcBuf, defaultCompressionLevel());
     }
 
@@ -831,7 +831,7 @@ public class Zstd {
      * @param level compression level
      * @return the size of the compressed data
      */
-    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf, int level, boolean checksumFlag) throws ZstdException {
+    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf, int level, boolean checksumFlag) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.setLevel(level);
@@ -868,7 +868,7 @@ public class Zstd {
         */
     }
 
-    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf, int level) throws ZstdException {
+    public static int compress(ByteBuffer dstBuf, ByteBuffer srcBuf, int level) {
         return compress(dstBuf, srcBuf, level, false);
     }
 
@@ -883,7 +883,7 @@ public class Zstd {
      * @param level compression level
      * @return A newly allocated direct ByteBuffer containing the compressed data.
      */
-    public static ByteBuffer compress(ByteBuffer srcBuf, int level) throws ZstdException {
+    public static ByteBuffer compress(ByteBuffer srcBuf, int level) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.setLevel(level);
@@ -900,7 +900,7 @@ public class Zstd {
      * @param dict dictionary to use
      * @return byte array with the compressed data
      */
-    public static byte[] compress(byte[] src, ZstdDictCompress dict) throws ZstdException {
+    public static byte[] compress(byte[] src, ZstdDictCompress dict) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -931,7 +931,7 @@ public class Zstd {
      * @return  compressed byte array
      */
 
-    public static byte[] compressUsingDict(byte[] src, byte[] dict, int level) throws ZstdException {
+    public static byte[] compressUsingDict(byte[] src, byte[] dict, int level) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -973,7 +973,7 @@ public class Zstd {
      * @param level compression level
      * @return  the number of bytes written into buffer 'dstBuff'
      */
-    public static int compress(ByteBuffer dstBuff, ByteBuffer srcBuff, byte[] dict, int level) throws ZstdException {
+    public static int compress(ByteBuffer dstBuff, ByteBuffer srcBuff, byte[] dict, int level) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -996,7 +996,7 @@ public class Zstd {
      * @param level compression level
      * @return  compressed direct byte buffer
      */
-    public static ByteBuffer compress(ByteBuffer srcBuff, byte[] dict, int level) throws ZstdException {
+    public static ByteBuffer compress(ByteBuffer srcBuff, byte[] dict, int level) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1019,7 +1019,7 @@ public class Zstd {
      * @param dict the dictionary buffer
      * @return  the number of bytes written into buffer 'dstBuff'
      */
-    public static int compress(ByteBuffer dstBuff, ByteBuffer srcBuff, ZstdDictCompress dict) throws ZstdException {
+    public static int compress(ByteBuffer dstBuff, ByteBuffer srcBuff, ZstdDictCompress dict) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1041,7 +1041,7 @@ public class Zstd {
      * @param dict the dictionary buffer
      * @return  compressed direct byte buffer
      */
-    public static ByteBuffer compress(ByteBuffer srcBuff, ZstdDictCompress dict) throws ZstdException {
+    public static ByteBuffer compress(ByteBuffer srcBuff, ZstdDictCompress dict) {
         ZstdCompressCtx ctx = new ZstdCompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1059,7 +1059,7 @@ public class Zstd {
      * @param originalSize the maximum size of the uncompressed data
      * @return byte array with the decompressed data
      */
-    public static byte[] decompress(byte[] src, int originalSize) throws ZstdException {
+    public static byte[] decompress(byte[] src, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             return ctx.decompress(src, originalSize);
@@ -1085,7 +1085,7 @@ public class Zstd {
      *               </p>
      * @return the size of the decompressed data.
      */
-    public static int decompress(ByteBuffer dstBuf, ByteBuffer srcBuf) throws ZstdException {
+    public static int decompress(ByteBuffer dstBuf, ByteBuffer srcBuf) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             return ctx.decompress(dstBuf, srcBuf);
@@ -1108,7 +1108,7 @@ public class Zstd {
      *          reading.  Note that this is different behavior from the other decompress() overload which takes as a parameter
      *          the destination ByteBuffer.
      */
-    public static ByteBuffer decompress(ByteBuffer srcBuf, int originalSize) throws ZstdException {
+    public static ByteBuffer decompress(ByteBuffer srcBuf, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             return ctx.decompress(srcBuf, originalSize);
@@ -1125,7 +1125,7 @@ public class Zstd {
      * @param originalSize the maximum size of the uncompressed data
      * @return byte array with the decompressed data
      */
-    public static byte[] decompress(byte[] src, ZstdDictDecompress dict, int originalSize) throws ZstdException {
+    public static byte[] decompress(byte[] src, ZstdDictDecompress dict, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1167,7 +1167,7 @@ public class Zstd {
      * @param originalSize the maximum size of the uncompressed data
      * @return byte array with the decompressed data
      */
-    public static byte[] decompress(byte[] src, byte[] dict, int originalSize) throws ZstdException {
+    public static byte[] decompress(byte[] src, byte[] dict, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1208,7 +1208,7 @@ public class Zstd {
      * @param dict   the dictionary buffer to use for compression
      * @return the size of the decompressed data.
      */
-    public static int decompress(ByteBuffer dstBuff, ByteBuffer srcBuff, byte[] dict) throws ZstdException {
+    public static int decompress(ByteBuffer dstBuff, ByteBuffer srcBuff, byte[] dict) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1233,7 +1233,7 @@ public class Zstd {
      *          reading.  Note that this is different behavior from the other decompress() overload which takes as a parameter
      *          the destination ByteBuffer.
      */
-    public static ByteBuffer decompress(ByteBuffer srcBuff, byte[] dict, int originalSize) throws ZstdException {
+    public static ByteBuffer decompress(ByteBuffer srcBuff, byte[] dict, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1261,7 +1261,7 @@ public class Zstd {
      * @param dict   the dictionary buffer to use for compression
      * @return the size of the decompressed data.
      */
-    public static int decompress(ByteBuffer dstBuff, ByteBuffer srcBuff, ZstdDictDecompress dict) throws ZstdException {
+    public static int decompress(ByteBuffer dstBuff, ByteBuffer srcBuff, ZstdDictDecompress dict) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);
@@ -1286,7 +1286,7 @@ public class Zstd {
      *          reading.  Note that this is different behavior from the other decompress() overload which takes as a parameter
      *          the destination ByteBuffer.
      */
-    public static ByteBuffer decompress(ByteBuffer srcBuff, ZstdDictDecompress dict, int originalSize) throws ZstdException {
+    public static ByteBuffer decompress(ByteBuffer srcBuff, ZstdDictDecompress dict, int originalSize) {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             ctx.loadDict(dict);

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
@@ -50,20 +50,20 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable
         return (int) recommendedDOutSize();
     }
 
-    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(byte[] dict) {
         long size = Zstd.loadDictDecompress(stream, dict, dict.length);
         if (Zstd.isError(size)) {
-            throw new IOException("Decompression error: " + Zstd.getErrorName(size));
+            throw new ZstdException(size);
         }
         return this;
     }
 
-    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) {
         dict.acquireSharedLock();
         try {
             long size = Zstd.loadFastDictDecompress(stream, dict);
             if (Zstd.isError(size)) {
-                throw new IOException("Decompression error: " + Zstd.getErrorName(size));
+                throw new ZstdException(size);
             }
         } finally {
             dict.releaseSharedLock();
@@ -86,7 +86,7 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable
 
         long remaining = decompressStream(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
         if (Zstd.isError(remaining)) {
-            throw new IOException(Zstd.getErrorName(remaining));
+            throw new ZstdException(remaining);
         }
 
         source.position(source.position() + consumed);
@@ -110,7 +110,7 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable
 
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (!closed) {
             try {
                 freeDStream(stream);

--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -19,7 +19,7 @@ public class ZstdInputStream extends FilterInputStream {
      * create a new decompressing InputStream
      * @param inStream the stream to wrap
      */
-    public ZstdInputStream(InputStream inStream) throws IOException {
+    public ZstdInputStream(InputStream inStream) {
         super(inStream);
         inner = new ZstdInputStreamNoFinalizer(inStream);
     }
@@ -29,7 +29,7 @@ public class ZstdInputStream extends FilterInputStream {
      * @param inStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdInputStream(InputStream inStream, BufferPool bufferPool) throws IOException {
+    public ZstdInputStream(InputStream inStream, BufferPool bufferPool) {
         super(inStream);
         inner = new ZstdInputStreamNoFinalizer(inStream, bufferPool);
     }
@@ -74,11 +74,11 @@ public class ZstdInputStream extends FilterInputStream {
         return inner.getContinuous();
     }
 
-    public ZstdInputStream setDict(byte[] dict) throws IOException {
+    public ZstdInputStream setDict(byte[] dict) {
         inner.setDict(dict);
         return this;
     }
-    public ZstdInputStream setDict(ZstdDictDecompress dict) throws IOException {
+    public ZstdInputStream setDict(ZstdDictDecompress dict) {
         inner.setDict(dict);
         return this;
     }

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -19,7 +19,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *  Use ZstdOutputStream() or ZstdOutputStream(level) and set the other params with the setters
      **/
     @Deprecated
-    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksums) throws IOException {
+    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksums) {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, level);
         inner.setCloseFrameOnFlush(closeFrameOnFlush);
@@ -31,7 +31,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *  Use ZstdOutputStream() or ZstdOutputStream(level) and set the other params with the setters
      **/
     @Deprecated
-    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush) throws IOException {
+    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush) {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, level);
         inner.setCloseFrameOnFlush(closeFrameOnFlush);
@@ -42,7 +42,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param level the compression level
      */
-    public ZstdOutputStream(OutputStream outStream, int level) throws IOException {
+    public ZstdOutputStream(OutputStream outStream, int level) {
         this(outStream, NoPool.INSTANCE);
         inner.setLevel(level);
     }
@@ -51,7 +51,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * create a new compressing OutputStream
      * @param outStream the stream to wrap
      */
-    public ZstdOutputStream(OutputStream outStream) throws IOException {
+    public ZstdOutputStream(OutputStream outStream) {
         this(outStream, NoPool.INSTANCE);
     }
 
@@ -60,7 +60,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool, int level) throws IOException {
+    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool, int level) {
         this(outStream, bufferPool);
         inner.setLevel(level);
     }
@@ -70,7 +70,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool) throws IOException {
+    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool) {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, bufferPool);
     }
@@ -103,7 +103,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: false
      */
-    public ZstdOutputStream setChecksum(boolean useChecksums) throws IOException {
+    public ZstdOutputStream setChecksum(boolean useChecksums) {
         inner.setChecksum(useChecksums);
         return this;
     }
@@ -113,7 +113,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: {@link Zstd#defaultCompressionLevel()}
      */
-    public ZstdOutputStream setLevel(int level) throws IOException {
+    public ZstdOutputStream setLevel(int level) {
         inner.setLevel(level);
         return this;
     }
@@ -123,7 +123,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Values for windowLog outside the range 10-27 will disable and reset LDM
      */
-    public ZstdOutputStream setLong(int windowLog) throws IOException {
+    public ZstdOutputStream setLong(int windowLog) {
         inner.setLong(windowLog);
         return this;
     }
@@ -133,7 +133,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: no worker threads.
      */
-    public ZstdOutputStream setWorkers(int n) throws IOException {
+    public ZstdOutputStream setWorkers(int n) {
         inner.setWorkers(n);
         return this;
     }
@@ -147,17 +147,17 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: false.
      */
-    public ZstdOutputStream setCloseFrameOnFlush(boolean closeOnFlush) throws IOException {
+    public ZstdOutputStream setCloseFrameOnFlush(boolean closeOnFlush) {
         inner.setCloseFrameOnFlush(closeOnFlush);
         return this;
     }
 
-    public ZstdOutputStream setDict(byte[] dict) throws IOException {
+    public ZstdOutputStream setDict(byte[] dict) {
         inner.setDict(dict);
         return this;
     }
 
-    public ZstdOutputStream setDict(ZstdDictCompress dict) throws IOException {
+    public ZstdOutputStream setDict(ZstdDictCompress dict) {
         inner.setDict(dict);
         return this;
     }


### PR DESCRIPTION
Initially we were throwing IOException for most of the errors. This does
no make it easy to tell if the problems is with the Zstd encoding or
with the underlying IO.