### PR TITLE
Fix exceptions

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
@@ -97,7 +97,7 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
                 result = initCStream(stream, level);
             }
             if (Zstd.isError(result)) {
-                throw new ZstdException(result);
+                throw new ZstdIOException(result);
             }
             initialized = true;
         }
@@ -113,7 +113,7 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
             }
             long result = compressDirectByteBuffer(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
             if (Zstd.isError(result)) {
-                throw new ZstdException(result);
+                throw new ZstdIOException(result);
             }
             target.position(target.position() + produced);
             source.position(source.position() + consumed);
@@ -130,7 +130,7 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
             do {
                 needed = flushStream(stream, target, target.position(), target.remaining());
                 if (Zstd.isError(needed)) {
-                    throw new ZstdException(needed);
+                    throw new ZstdIOException(needed);
                 }
                 target.position(target.position() + produced);
                 target = flushBuffer(target);
@@ -155,7 +155,7 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
                     do {
                         needed = endStream(stream, target, target.position(), target.remaining());
                         if (Zstd.isError(needed)) {
-                            throw new ZstdException(needed);
+                            throw new ZstdIOException(needed);
                         }
                         target.position(target.position() + produced);
                         target = flushBuffer(target);

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
@@ -50,20 +50,20 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable
         return (int) recommendedDOutSize();
     }
 
-    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(byte[] dict) {
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
         long size = Zstd.loadDictDecompress(stream, dict, dict.length);
         if (Zstd.isError(size)) {
-            throw new ZstdException(size);
+            throw new ZstdIOException(size);
         }
         return this;
     }
 
-    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) {
+    public ZstdDirectBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
         dict.acquireSharedLock();
         try {
             long size = Zstd.loadFastDictDecompress(stream, dict);
             if (Zstd.isError(size)) {
-                throw new ZstdException(size);
+                throw new ZstdIOException(size);
             }
         } finally {
             dict.releaseSharedLock();
@@ -86,7 +86,7 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer implements Closeable
 
         long remaining = decompressStream(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
         if (Zstd.isError(remaining)) {
-            throw new ZstdException(remaining);
+            throw new ZstdIOException(remaining);
         }
 
         source.position(source.position() + consumed);

--- a/src/main/java/com/github/luben/zstd/ZstdIOException.java
+++ b/src/main/java/com/github/luben/zstd/ZstdIOException.java
@@ -1,0 +1,47 @@
+package com.github.luben.zstd;
+
+import java.io.IOException;
+
+public class ZstdIOException extends IOException {
+    private long code;
+
+    /**
+     * Construct a ZstdException from the result of a Zstd library call.
+     *
+     * The error code and message are automatically looked up using
+     * Zstd.getErrorCode and Zstd.getErrorName.
+     *
+     * @param result the return value of a Zstd library call
+     */
+    public ZstdIOException(long result) {
+        this(Zstd.getErrorCode(result), Zstd.getErrorName(result));
+    }
+
+    /**
+     * Construct a ZstdException with a manually-specified error code and message.
+     *
+     * No transformation of either the code or message is done. It is advised
+     * that one of the Zstd.err*() is used to obtain a stable error code.
+     *
+     * @param code a Zstd error code
+     * @param message the exception's message
+     */
+    public ZstdIOException(long code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    /**
+     * Get the Zstd error code that caused the exception.
+     *
+     * This will likely correspond to one of the Zstd.err*() methods, but the
+     * Zstd library may return error codes that are not yet stable. In such
+     * cases, this method will return the code reported by Zstd, but it will
+     * not correspond to any of the Zstd.err*() methods.
+     *
+     * @return a Zstd error code
+     */
+    public long getErrorCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -19,7 +19,7 @@ public class ZstdInputStream extends FilterInputStream {
      * create a new decompressing InputStream
      * @param inStream the stream to wrap
      */
-    public ZstdInputStream(InputStream inStream) {
+    public ZstdInputStream(InputStream inStream) throws IOException {
         super(inStream);
         inner = new ZstdInputStreamNoFinalizer(inStream);
     }
@@ -29,7 +29,7 @@ public class ZstdInputStream extends FilterInputStream {
      * @param inStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdInputStream(InputStream inStream, BufferPool bufferPool) {
+    public ZstdInputStream(InputStream inStream, BufferPool bufferPool) throws IOException {
         super(inStream);
         inner = new ZstdInputStreamNoFinalizer(inStream, bufferPool);
     }
@@ -74,11 +74,11 @@ public class ZstdInputStream extends FilterInputStream {
         return inner.getContinuous();
     }
 
-    public ZstdInputStream setDict(byte[] dict) {
+    public ZstdInputStream setDict(byte[] dict) throws IOException {
         inner.setDict(dict);
         return this;
     }
-    public ZstdInputStream setDict(ZstdDictDecompress dict) {
+    public ZstdInputStream setDict(ZstdDictDecompress dict) throws IOException {
         inner.setDict(dict);
         return this;
     }

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStream.java
@@ -19,7 +19,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *  Use ZstdOutputStream() or ZstdOutputStream(level) and set the other params with the setters
      **/
     @Deprecated
-    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksums) {
+    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush, boolean useChecksums) throws IOException {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, level);
         inner.setCloseFrameOnFlush(closeFrameOnFlush);
@@ -31,7 +31,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *  Use ZstdOutputStream() or ZstdOutputStream(level) and set the other params with the setters
      **/
     @Deprecated
-    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush) {
+    public ZstdOutputStream(OutputStream outStream, int level, boolean closeFrameOnFlush) throws IOException {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, level);
         inner.setCloseFrameOnFlush(closeFrameOnFlush);
@@ -42,7 +42,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param level the compression level
      */
-    public ZstdOutputStream(OutputStream outStream, int level) {
+    public ZstdOutputStream(OutputStream outStream, int level) throws IOException {
         this(outStream, NoPool.INSTANCE);
         inner.setLevel(level);
     }
@@ -51,7 +51,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * create a new compressing OutputStream
      * @param outStream the stream to wrap
      */
-    public ZstdOutputStream(OutputStream outStream) {
+    public ZstdOutputStream(OutputStream outStream) throws IOException {
         this(outStream, NoPool.INSTANCE);
     }
 
@@ -60,7 +60,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool, int level) {
+    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool, int level) throws IOException {
         this(outStream, bufferPool);
         inner.setLevel(level);
     }
@@ -70,7 +70,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      * @param outStream the stream to wrap
      * @param bufferPool the pool to fetch and return buffers
      */
-    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool) {
+    public ZstdOutputStream(OutputStream outStream, BufferPool bufferPool) throws IOException {
         super(outStream);
         inner = new ZstdOutputStreamNoFinalizer(outStream, bufferPool);
     }
@@ -103,7 +103,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: false
      */
-    public ZstdOutputStream setChecksum(boolean useChecksums) {
+    public ZstdOutputStream setChecksum(boolean useChecksums) throws IOException {
         inner.setChecksum(useChecksums);
         return this;
     }
@@ -113,7 +113,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: {@link Zstd#defaultCompressionLevel()}
      */
-    public ZstdOutputStream setLevel(int level) {
+    public ZstdOutputStream setLevel(int level) throws IOException {
         inner.setLevel(level);
         return this;
     }
@@ -123,7 +123,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Values for windowLog outside the range 10-27 will disable and reset LDM
      */
-    public ZstdOutputStream setLong(int windowLog) {
+    public ZstdOutputStream setLong(int windowLog) throws IOException {
         inner.setLong(windowLog);
         return this;
     }
@@ -133,7 +133,7 @@ public class ZstdOutputStream extends FilterOutputStream{
      *
      * Default: no worker threads.
      */
-    public ZstdOutputStream setWorkers(int n) {
+    public ZstdOutputStream setWorkers(int n) throws IOException {
         inner.setWorkers(n);
         return this;
     }
@@ -152,12 +152,12 @@ public class ZstdOutputStream extends FilterOutputStream{
         return this;
     }
 
-    public ZstdOutputStream setDict(byte[] dict) {
+    public ZstdOutputStream setDict(byte[] dict) throws IOException {
         inner.setDict(dict);
         return this;
     }
 
-    public ZstdOutputStream setDict(ZstdDictCompress dict) {
+    public ZstdOutputStream setDict(ZstdDictCompress dict) throws IOException {
         inner.setDict(dict);
         return this;
     }


### PR DESCRIPTION
So that we don't break backward compatibility - ZstdIOException is
subclass of the IOException so signatures don't have to be changed.