### PR TITLE
ZstdCompressCtx: add method to get frame progression

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -198,6 +198,16 @@ public class ZstdCompressCtx extends AutoCloseBase {
     }
 
     /**
+     * Tells how much data has been ingested (read from input),
+     * consumed (input actually compressed) and produced (output) for current frame.
+     */
+    public ZstdFrameProgression getFrameProgression() {
+        ensureOpen();
+        return getFrameProgression0();
+    }
+    private native ZstdFrameProgression getFrameProgression0();
+    
+    /**
      * Clear all state and parameters from the compression context. This leaves the object in a
      * state identical to a newly created compression context.
      */

--- a/src/main/java/com/github/luben/zstd/ZstdFrameProgression.java
+++ b/src/main/java/com/github/luben/zstd/ZstdFrameProgression.java
@@ -1,0 +1,65 @@
+package com.github.luben.zstd;
+
+public class ZstdFrameProgression {
+    
+    private long ingested;
+    private long consumed;
+    private long produced;
+    private long flushed;
+    private int currentJobID;
+    private int nbActiveWorkers;
+    
+    public ZstdFrameProgression(long ingested, long consumed, long produced, long flushed, int currentJobID,
+            int nbActiveWorkers) {
+        this.ingested = ingested;
+        this.consumed = consumed;
+        this.produced = produced;
+        this.flushed = flushed;
+        this.currentJobID = currentJobID;
+        this.nbActiveWorkers = nbActiveWorkers;
+    }
+
+    /**
+     * The number of input bytes read and buffered.
+     */
+    public long getIngested() {
+        return ingested;
+    }
+
+    /**
+     * The number of input bytes actually compressed.
+     * Note: ingested - consumed = amount of input data buffered internally, not yet compressed.
+     */
+    public long getConsumed() {
+        return consumed;
+    }
+
+    /**
+     * The number of compressed bytes generated and buffered.
+     */
+    public long getProduced() {
+        return produced;
+    }
+
+    /**
+     * The number of compressed bytes flushed.
+     */
+    public long getFlushed() {
+        return flushed;
+    }
+
+    /**
+     * The last started job number. Only applicable if multi-threading is enabled.
+     */
+    public int getCurrentJobID() {
+        return currentJobID;
+    }
+
+    /**
+     * The number of workers actively compressing. Only applicable if multi-threading is enabled.
+     */
+    public int getNbActiveWorkers() {
+        return nbActiveWorkers;
+    }
+    
+}

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -1,3 +1,6 @@
+#ifndef ZSTD_STATIC_LINKING_ONLY
+#define ZSTD_STATIC_LINKING_ONLY
+#endif
 #include <jni.h>
 #include <zstd.h>
 #include <zstd_errors.h>
@@ -328,6 +331,19 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_reset0
   (JNIEnv *env, jclass jctx) {
     ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t)(*env)->GetLongField(env, jctx, compress_ctx_nativePtr);
     return ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters);
+}
+
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_getFrameProgression0
+  (JNIEnv *env, jclass jctx) {
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t)(*env)->GetLongField(env, jctx, compress_ctx_nativePtr);
+    ZSTD_frameProgression native_progression = ZSTD_getFrameProgression(cctx);
+    
+    jclass frame_progression_class = (*env)->FindClass(env, "com/github/luben/zstd/ZstdFrameProgression");
+    jmethodID frame_progression_constructor = (*env)->GetMethodID(env, frame_progression_class, "<init>", "(JJJJII)V");
+    return (*env)->NewObject(
+            env, frame_progression_class, frame_progression_constructor, native_progression.ingested,
+            native_progression.consumed, native_progression.produced, native_progression.flushed,
+            native_progression.currentJobID, native_progression.nbActiveWorkers);
 }
 
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_setPledgedSrcSize0

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -895,9 +895,17 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
             compressedBuffer.limit(compressedBuffer.position() + 1)
             cctx.compressDirectByteBufferStream(compressedBuffer, inputBuffer, EndDirective.CONTINUE)
           }
+          
+          var frameProgression = cctx.getFrameProgression()
+          assert(frameProgression.getIngested() == size)
+          assert(frameProgression.getFlushed() == compressedBuffer.position())
+          
           compressedBuffer.limit(compressedBuffer.capacity())
           val done = cctx.compressDirectByteBufferStream(compressedBuffer, inputBuffer, EndDirective.END)
           assert(done)
+          
+          frameProgression = cctx.getFrameProgression()
+          assert(frameProgression.getConsumed() == size)
 
           compressedBuffer.flip()
           val decompressedBuffer = ByteBuffer.allocateDirect(size)


### PR DESCRIPTION
When performing compression in a streaming fashion, the position of the input buffer does not accurately indicate how much input has actually been compressed, because zstd has its own internal buffers.

The getFrameProgression() function allows the user to get accurate numbers.