### PR TITLE
Add ZstdBufferDecompressingStreamNoFinalizer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ jniNativeClasses := Seq(
   "com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
   "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
   "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer",
-  "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+  "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer",
+  "com.github.luben.zstd.ZstdBufferDecompressingStreamNoFinalizer"
 )
 
 jniLibSuffix := (System.getProperty("os.name").toLowerCase match {

--- a/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
@@ -1,0 +1,118 @@
+package com.github.luben.zstd;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Closeable {
+    protected long stream;
+    protected ByteBuffer source;
+    protected boolean closed = false;
+    private boolean finishedFrame = false;
+    private boolean streamEnd = false;
+    private int consumed;
+    private int produced;
+
+    public BaseZstdBufferDecompressingStreamNoFinalizer(ByteBuffer source) {
+        this.source = source;
+    }
+
+    /**
+     * Override this method in case the byte buffer passed to the constructor might not contain the full compressed stream
+     *
+     * @param toRefill current buffer
+     * @return either the current buffer (but refilled and flipped if there was new content) or a new buffer.
+     */
+    protected ByteBuffer refill(ByteBuffer toRefill) {
+        return toRefill;
+    }
+
+    public boolean hasRemaining() {
+        return !streamEnd && (source.hasRemaining() || !finishedFrame);
+    }
+
+    BaseZstdBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
+        long size = Zstd.loadDictDecompress(stream, dict, dict.length);
+        if (Zstd.isError(size)) {
+            throw new ZstdIOException(size);
+        }
+        return this;
+    }
+
+    BaseZstdBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
+        dict.acquireSharedLock();
+        try {
+            long size = Zstd.loadFastDictDecompress(stream, dict);
+            if (Zstd.isError(size)) {
+                throw new ZstdIOException(size);
+            }
+        } finally {
+            dict.releaseSharedLock();
+        }
+        return this;
+    }
+
+    BaseZstdBufferDecompressingStreamNoFinalizer setLongMax(int windowLogMax) throws IOException {
+        long size = Zstd.setDecompressionLongMax(stream, windowLogMax);
+        if (Zstd.isError(size)) {
+            throw new ZstdIOException(size);
+        }
+        return this;
+    }
+
+    int readInternal(ByteBuffer target, boolean isDirectBufferRequired) throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+        if (streamEnd) {
+            return 0;
+        }
+
+        long remaining = decompressStream(stream, target, target.position(), target.remaining(), source, source.position(), source.remaining());
+        if (Zstd.isError(remaining)) {
+            throw new ZstdIOException(remaining);
+        }
+
+        source.position(source.position() + consumed);
+        target.position(target.position() + produced);
+
+        if (!source.hasRemaining()) {
+            source = refill(source);
+            if (!isDirectBufferRequired && source.isDirect()) {
+                throw new IllegalArgumentException("Source buffer should be a non-direct buffer");
+            }
+            if (isDirectBufferRequired && !source.isDirect()) {
+                throw new IllegalArgumentException("Source buffer should be a direct buffer");
+            }
+        }
+
+        finishedFrame = remaining == 0;
+        if (finishedFrame) {
+            // nothing left, so at end of the stream
+            streamEnd = !source.hasRemaining();
+        }
+
+        return produced;
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            try {
+                freeDStream(stream);
+            } finally {
+                closed = true;
+                source = null; // help GC with realizing the buffer can be released
+            }
+        }
+    }
+    public abstract int read(ByteBuffer target) throws IOException;
+
+    abstract long createDStream();
+
+    abstract long freeDStream(long stream);
+
+    abstract long initDStream(long stream);
+
+    abstract long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+}

--- a/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
@@ -13,7 +13,7 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
     private int consumed;
     private int produced;
 
-    public BaseZstdBufferDecompressingStreamNoFinalizer(ByteBuffer source) {
+    BaseZstdBufferDecompressingStreamNoFinalizer(ByteBuffer source) {
         this.source = source;
     }
 
@@ -26,12 +26,12 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
     protected ByteBuffer refill(ByteBuffer toRefill) {
         return toRefill;
     }
-
+    
     public boolean hasRemaining() {
         return !streamEnd && (source.hasRemaining() || !finishedFrame);
     }
 
-    BaseZstdBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
+    public BaseZstdBufferDecompressingStreamNoFinalizer setDict(byte[] dict) throws IOException {
         long size = Zstd.loadDictDecompress(stream, dict, dict.length);
         if (Zstd.isError(size)) {
             throw new ZstdIOException(size);
@@ -39,7 +39,7 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
         return this;
     }
 
-    BaseZstdBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
+    public BaseZstdBufferDecompressingStreamNoFinalizer setDict(ZstdDictDecompress dict) throws IOException {
         dict.acquireSharedLock();
         try {
             long size = Zstd.loadFastDictDecompress(stream, dict);
@@ -52,7 +52,7 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
         return this;
     }
 
-    BaseZstdBufferDecompressingStreamNoFinalizer setLongMax(int windowLogMax) throws IOException {
+    public BaseZstdBufferDecompressingStreamNoFinalizer setLongMax(int windowLogMax) throws IOException {
         long size = Zstd.setDecompressionLongMax(stream, windowLogMax);
         if (Zstd.isError(size)) {
             throw new ZstdIOException(size);

--- a/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStream.java
@@ -1,0 +1,87 @@
+package com.github.luben.zstd;
+
+import com.github.luben.zstd.util.Native;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class ZstdBufferDecompressingStream implements Closeable {
+
+    static {
+        Native.load();
+    }
+
+    /**
+     * Override this method in case the byte buffer passed to the constructor might not contain the full compressed stream
+     *
+     * @param toRefill current buffer
+     * @return either the current buffer (but refilled and flipped if there was new content) or a new buffer.
+     */
+    protected ByteBuffer refill(ByteBuffer toRefill) {
+        return toRefill;
+    }
+
+    private final ZstdBufferDecompressingStreamNoFinalizer inner;
+    private boolean finalize = true;
+
+    public ZstdBufferDecompressingStream(ByteBuffer source) {
+        inner = new ZstdBufferDecompressingStreamNoFinalizer(source) {
+            @Override
+            protected ByteBuffer refill(ByteBuffer toRefill) {
+                return ZstdBufferDecompressingStream.this.refill(toRefill);
+            }
+        };
+    }
+
+    /**
+     * Enable or disable class finalizers
+     * <p>
+     * If finalizers are disabled the responsibility fir calling the `close` method is on the consumer.
+     *
+     * @param finalize default `true` - finalizers are enabled
+     */
+    public void setFinalize(boolean finalize) {
+        this.finalize = finalize;
+    }
+
+    public synchronized boolean hasRemaining() {
+        return inner.hasRemaining();
+    }
+
+    public static int recommendedTargetBufferSize() {
+        return ZstdBufferDecompressingStreamNoFinalizer.recommendedTargetBufferSize();
+    }
+
+    public synchronized ZstdBufferDecompressingStream setDict(byte[] dict) throws IOException {
+        inner.setDict(dict);
+        return this;
+    }
+
+    public synchronized ZstdBufferDecompressingStream setDict(ZstdDictDecompress dict) throws IOException {
+        inner.setDict(dict);
+        return this;
+    }
+
+    public ZstdBufferDecompressingStream setLongMax(int windowLogMax) throws IOException {
+        inner.setLongMax(windowLogMax);
+        return this;
+    }
+
+
+    public synchronized int read(ByteBuffer target) throws IOException {
+        return inner.read(target);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        inner.close();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        if (finalize) {
+            close();
+        }
+    }
+}

--- a/src/main/native/jni_bufferdecompress_zstd.c
+++ b/src/main/native/jni_bufferdecompress_zstd.c
@@ -1,0 +1,86 @@
+#include <jni.h>
+#include <zstd.h>
+#include <zstd_errors.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/* field IDs can't change in the same VM */
+static jfieldID consumed_id;
+static jfieldID produced_id;
+
+/*
+ * Class:     com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer
+ * Method:    recommendedDOutSizeNative
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_recommendedDOutSizeNative
+  (JNIEnv *env, jclass obj) {
+    return ZSTD_DStreamOutSize();
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer
+ * Method:    createDStreamNative
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_createDStreamNative
+  (JNIEnv *env, jclass obj) {
+    return (jlong)(intptr_t) ZSTD_createDStream();
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer
+ * Method:    freeDStreamNative
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_freeDStreamNative
+  (JNIEnv *env, jclass obj, jlong stream) {
+    return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer
+ * Method:    initDStreamNative
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_initDStreamNative
+  (JNIEnv *env, jclass obj, jlong stream) {
+    jclass clazz = (*env)->GetObjectClass(env, obj);
+    consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
+    produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
+    return ZSTD_initDStream((ZSTD_DCtx *)(intptr_t) stream);
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer
+ * Method:    decompressStreamNative
+ * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)I
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_decompressStreamNative
+  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
+    // input validation
+    if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
+    if (NULL == src) return -ZSTD_error_srcSize_wrong;
+    if (0 > dst_offset) return -ZSTD_error_dstSize_tooSmall;
+    if (0 > src_offset) return -ZSTD_error_srcSize_wrong;
+    if (0 > src_size) return -ZSTD_error_srcSize_wrong;
+    if (0 > dst_size) return -ZSTD_error_dstSize_tooSmall;
+    if (src_offset + src_size > (*env)->GetArrayLength(env, src)) return -ZSTD_error_srcSize_wrong;
+    if (dst_offset + dst_size > (*env)->GetArrayLength(env, dst)) return -ZSTD_error_dstSize_tooSmall;
+
+    size_t size = -ZSTD_error_memory_allocation;
+    char *dst_buf_ptr = (char*)(*env)->GetPrimitiveArrayCritical(env, dst, NULL);
+    if (dst_buf_ptr == NULL) goto E1;
+    char *src_buf_ptr = (char*)(*env)->GetPrimitiveArrayCritical(env, src, NULL);
+    if (src_buf_ptr == NULL) goto E2;
+
+    ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0};
+    ZSTD_inBuffer input = { src_buf_ptr + src_offset, src_size, 0};
+
+    size = ZSTD_decompressStream((ZSTD_DCtx *)(intptr_t) stream, &output, &input);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, src, src_buf_ptr, JNI_ABORT);
+E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buf_ptr, 0);
+    (*env)->SetIntField(env, obj, consumed_id, input.pos);
+    (*env)->SetIntField(env, obj, produced_id, output.pos);
+E1: return size;
+}

--- a/src/main/native/jni_directbufferdecompress_zstd.c
+++ b/src/main/native/jni_directbufferdecompress_zstd.c
@@ -10,39 +10,39 @@ static jfieldID produced_id;
 
 /*
  * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
- * Method:    recommendedDOutSize
+ * Method:    recommendedDOutSizeNative
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_recommendedDOutSize
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_recommendedDOutSizeNative
   (JNIEnv *env, jclass obj) {
     return ZSTD_DStreamOutSize();
 }
 
 /*
  * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
- * Method:    createDStream
+ * Method:    createDStreamNative
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_createDStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_createDStreamNative
   (JNIEnv *env, jclass obj) {
     return (jlong)(intptr_t) ZSTD_createDStream();
 }
 
 /*
  * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
- * Method:    freeDStream
+ * Method:    freeDStreamNative
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_freeDStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_freeDStreamNative
   (JNIEnv *env, jclass obj, jlong stream) {
     return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
 }
 
 /*
  * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
- * Method:    initDStream
+ * Method:    initDStreamNative
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_initDStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_initDStreamNative
   (JNIEnv *env, jclass obj, jlong stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
@@ -52,10 +52,10 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
 
 /*
  * Class:     com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer
- * Method:    decompressStream
+ * Method:    decompressStreamNative
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)I
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_decompressStream
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_decompressStreamNative
   (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
     size_t size = -ZSTD_error_memory_allocation;
 


### PR DESCRIPTION
**Motivation**
At Apache Kafka, [we always have the entire compression buffer](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/compress/ZstdFactory.java#L67) before we send it to Zstd to decompress. Hence, we don't need a stream to provide the buffer containing compressed data to Zstd. There is no interface in Zstd-JNI which allows to submit a buffer (containing compressed data) and return an InputStream containing uncompressed data.

**Changes**
1. Add a new interface `ZstdBufferDecompressingStreamNoFinalizer` which is similar to existing `ZstdDirectBufferDecompressingStreamNoFinalizer`, except, it works with heap buffers.
2. Refactor to extract out a common base class from the two classes above.

**Testing**
Added tests for the new interface.
