### PR TITLE
Relax the requirement for source and target ByteBuffer in ZstdBufferDecompressingStream

### DIFF
--- a/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
@@ -10,7 +10,13 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
     protected boolean closed = false;
     private boolean finishedFrame = false;
     private boolean streamEnd = false;
+    /**
+     * This field is set by the native call to represent the number of bytes consumed from {@link #source} buffer.
+     */
     private int consumed;
+    /**
+     * This field is set by the native call to represent the number of bytes produced into the target buffer.
+     */
     private int produced;
 
     BaseZstdBufferDecompressingStreamNoFinalizer(ByteBuffer source) {
@@ -27,6 +33,9 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
         return toRefill;
     }
 
+    /**
+     * @return false if all data is processed and no more data is available from the {@link #source}
+     */
     public boolean hasRemaining() {
         return !streamEnd && (source.hasRemaining() || !finishedFrame);
     }
@@ -52,6 +61,15 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
         return this;
     }
 
+    /**
+     * Set the value of zstd parameter <code>ZSTD_d_windowLogMax</code>.
+     *
+     * @param windowLogMax window size in bytes
+     * @return this instance of {@link BaseZstdBufferDecompressingStreamNoFinalizer}
+     * @throws ZstdIOException if there is an error while setting the configuration natively.
+     *
+     * @see <a href="https://github.com/facebook/zstd/blob/0525d1cec64a8df749ff293ee476f616de79f7b0/lib/zstd.h#L606"> Zstd's ZSTD_d_windowLogMax parameter</a>
+     */
     public BaseZstdBufferDecompressingStreamNoFinalizer setLongMax(int windowLogMax) throws IOException {
         long size = Zstd.setDecompressionLongMax(stream, windowLogMax);
         if (Zstd.isError(size)) {
@@ -106,6 +124,23 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
             }
         }
     }
+
+    /**
+     * Reads the content of the de-compressed stream into the target buffer.
+     * <p>This method will block until the chunk of compressed data stored in {@link #source} has been decompressed and
+     * written into the target buffer. After each execution, this method will refill the {@link #source} buffer, using
+     * {@link #refill(ByteBuffer)}.
+     *<p>To read the full stream of decompressed data, this method should be called in a loop while {@link #hasRemaining()}
+     * is <code>true</code>.
+     *<p>The target buffer will be written starting from {@link ByteBuffer#position()}. The {@link ByteBuffer#position()}
+     * of source and the target buffers will be modified to represent the data read and written respectively.
+     *
+     * @param target buffer to store the read bytes from uncompressed stream.
+     * @return the number of bytes read into the target buffer.
+     * @throws ZstdIOException if an error occurs while reading.
+     * @throws IllegalArgumentException if provided source or target buffers are incorrectly configured.
+     * @throws IOException if the stream is closed before reading.
+     */
     public abstract int read(ByteBuffer target) throws IOException;
 
     abstract long createDStream();

--- a/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
@@ -15,8 +15,8 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
         if (source.isDirect()) {
             throw new IllegalArgumentException("Source buffer should be a non-direct buffer");
         }
-        stream = createDStreamNative();
-        initDStreamNative(stream);
+        stream = createDStream();
+        initDStream(stream);
     }
 
     @Override
@@ -44,8 +44,14 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
 
     @Override
     long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize) {
-        byte[] targetArr = Zstd.extractArray(dst);
-        byte[] sourceArr = Zstd.extractArray(source);
+        if (!src.hasArray()) {
+            throw new IllegalArgumentException("provided source ByteBuffer lacks array");
+        }
+        if (!dst.hasArray()) {
+            throw new IllegalArgumentException("provided destination ByteBuffer lacks array");
+        }
+        byte[] targetArr = dst.array();
+        byte[] sourceArr = src.array();
 
         return decompressStreamNative(stream, targetArr, dstOffset, dstSize, sourceArr, srcOffset, srcSize);
     }

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
@@ -16,8 +16,8 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer extends BaseZstdBuff
             throw new IllegalArgumentException("Source buffer should be a direct buffer");
         }
         this.source = source;
-        stream = createDStreamNative();
-        initDStreamNative(stream);
+        stream = createDStream();
+        initDStream(stream);
     }
 
     @Override

--- a/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
@@ -140,7 +140,7 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
             throw new IOException("Stream closed");
         }
 
-        // guard agains buffer overflows
+        // guard against buffer overflows
         if (offset < 0 || len > dst.length - offset) {
             throw new IndexOutOfBoundsException("Requested length " + len
                     + " from offset " + offset + " in buffer of size " + dst.length);


### PR DESCRIPTION
resolves https://github.com/luben/zstd-jni/issues/252

# Motivation
At https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java#L47-L48 extractArray() ensures that the buffer.arrayOffset() != 0. However, that is not a strict requirement for ZstdBufferDecompressingStream since it works with the case [1] where ByteBuffer may have a non-zero position.

# Change
- Remove the constraints that ensure that source & destination buffer have position at 0.
- Added some documentation to the public methods.

# Testing 
- Modified existing unit tests to include cases where the source and target buffers don't have position starting from 0.
- `./sbt clean compile test` is successful