### PR TITLE
Add support for multiple dictionary references in streaming decompression

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -567,6 +567,7 @@ public class Zstd {
     public static native int setCompressionWorkers(long stream, int workers);
     public static native int setDecompressionLongMax(long stream, int windowLogMax);
     public static native int setDecompressionMagicless(long stream, boolean useMagicless);
+    public static native int setRefMultipleDDicts(long stream, boolean useMultiple);
 
     /* Utility methods */
 

--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -88,6 +88,17 @@ public class ZstdInputStream extends FilterInputStream {
         return this;
     }
 
+    /**
+     * Enable or disable support for multiple dictionary references
+     *
+     * @param useMultiple Enables references table for DDict, so the DDict used for decompression will be
+     *                    determined per the dictId in the frame, default: false
+     */
+    public ZstdInputStream setRefMultipleDDicts(boolean useMultiple) throws IOException {
+        inner.setRefMultipleDDicts(useMultiple);
+        return this;
+    }
+
     public int read(byte[] dst, int offset, int len) throws IOException {
         return inner.read(dst, offset, len);
     }

--- a/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
@@ -117,6 +117,14 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
         return this;
     }
 
+    public synchronized ZstdInputStreamNoFinalizer setRefMultipleDDicts(boolean useMultiple) throws IOException {
+        int size = Zstd.setRefMultipleDDicts(stream, useMultiple);
+        if (Zstd.isError(size)) {
+            throw new ZstdIOException(size);
+        }
+        return this;
+    }
+
     public synchronized int read(byte[] dst, int offset, int len) throws IOException {
         // guard agains buffer overflows
         if (offset < 0 || len > dst.length - offset) {

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -334,6 +334,17 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_setCompressionWorkers
 
 /*
  * Class:     com_github_luben_zstd_Zstd
+ * Method:    setRefMultipleDDicts
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_setRefMultipleDDicts
+  (JNIEnv *env, jclass obj, jlong stream, jboolean enabled) {
+    ZSTD_refMultipleDDicts_e value = enabled ? ZSTD_rmd_refMultipleDDicts : ZSTD_rmd_refSingleDDict;
+    return ZSTD_DCtx_setParameter((ZSTD_DCtx *)(intptr_t) stream, ZSTD_d_refMultipleDDicts, value);
+}
+
+/*
+ * Class:     com_github_luben_zstd_Zstd
  * Methods:   header constants access
  * Signature: ()I
  */


### PR DESCRIPTION
resolves #261.

Added setting `ZSTD_d_refMultipleDDicts` that enables support for multiple dictionary references in a decompression streaming context. With `refMultipleDDicts -> true`, zstd searches for a suitable dictionary by matching the dictionaryId in the frame among known dictionaries (loaded via `setDict`).