### PR TITLE
Fix bug in ZstdBufferDecompressingStream when array backing ByteBuffer is shared

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
@@ -43,7 +43,7 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
     }
 
     @Override
-    long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize) {
+    long decompressStream(long stream, ByteBuffer dst, int dstBufPos, int dstSize, ByteBuffer src, int srcBufPos, int srcSize) {
         if (!src.hasArray()) {
             throw new IllegalArgumentException("provided source ByteBuffer lacks array");
         }
@@ -53,7 +53,10 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
         byte[] targetArr = dst.array();
         byte[] sourceArr = src.array();
 
-        return decompressStreamNative(stream, targetArr, dstOffset, dstSize, sourceArr, srcOffset, srcSize);
+        // We are interested in array data corresponding to the pos represented by the ByteBuffer view.
+        // A ByteBuffer may share an underlying array with other ByteBuffers. In such scenario, we need to adjust the
+        // index of the array by adding an offset using arrayOffset().
+        return decompressStreamNative(stream, targetArr, dstBufPos + dst.arrayOffset(), dstSize, sourceArr, srcBufPos + src.arrayOffset(), srcSize);
     }
 
     public static int recommendedTargetBufferSize() {


### PR DESCRIPTION
## Motivation
The current implementation of ZstdBufferDecompressingStream fails with `com.github.luben.zstd.ZstdIOException: Unknown frame descriptor` when the interface is used with a ByteBuffer which is backed by an array which is shared with other ByteBuffers. This is a bug in the implementation where we assume that the ByteBuffer represents the view of the entire backing array.

## Change
Change the implementation to specifically use the array represented by the bytebuffer view instead of the entire backing array.

## Testing
Added a test case which fails prior to the change and passes after it.