### PR TITLE
Enable support for internal jdk

### DIFF
--- a/sbt
+++ b/sbt
@@ -218,6 +218,8 @@ getJavaVersion() {
     echo "${BASH_REMATCH[1]}"
   elif [[ "$str" =~ ^([0-9]+)(\..*)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
+  elif [[ "$str" =~ ^([0-9]+)-internal$ ]]; then
+    echo "${BASH_REMATCH[1]}"
   elif [[ -n "$str" ]]; then
     echoerr "Can't parse java version from: $str"
   fi


### PR DESCRIPTION
Hi,
( I'm new to zstd-jni, please kindly let me know if I need to follow some process for this pr. )
Can I have a review of this simple patch? It enables support for internal jdk, which has version string like: openjdk version 22-internal 2024-03-19. It helps during the development of jdk.

Thanks!