### PR TITLE
Migrate supported java version from 1.6 to 1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,9 +27,9 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % "test"
 )
 
-javacOptions ++= Seq("--release", "6", "-Xlint:unchecked")
+javacOptions ++= Seq("--release", "8", "-Xlint:unchecked")
 
-doc / javacOptions := Seq("--release", "6")
+doc / javacOptions := Seq("--release", "8")
 
 // fork := true
 // Check at runtime for JNI errors when running tests
@@ -210,7 +210,7 @@ OsgiKeys.privatePackage := Seq(
 )
 // Explicitly specify the version of JavaSE required
 // (rather depend on figuring that out from the JDK it was built with)
-OsgiKeys.requireCapability := "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version>=1.6))\""
+OsgiKeys.requireCapability := "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version>=1.8))\""
 
 // Jacoco coverage setting
 jacocoReportSettings := JacocoReportSettings(


### PR DESCRIPTION
Hi,

Can I have a discussion about the supported jdk versions of zstd-jni?
In the `build.sbt`, jdk1.6 is still supported:
```
javacOptions ++= Seq("--release", "6", "-Xlint:unchecked")
...
doc / javacOptions := Seq("--release", "6")
...
OsgiKeys.requireCapability := "osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version>=1.6))\""
```

I'm not sure if this is necessary, but seems this blocks the usage of zstd-jni in jdk 17/21 and later?
```
$ javac -version
javac 17.0.2
hamlin@hamlin:~/workspace/tools$ javac --release 6 Test.java
error: release version 6 not supported
Usage: javac <options> <source files>
use --help for a list of possible options
```

Do we have a plan to migrate the supportted jdk version from 1.6 to 1.8? If positive, this is the pr to do it.


Thanks!