### PR TITLE
Enable basic support for riscv64

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The binary releases are architecture dependent because we are embedding the
 native library in the provided Jar file. Currently they are built for
 *linux-amd64*, *linux-i386*, *linux-aarch64*, *linux-armhf*, *linux-ppc64*,
 *linux-ppc64le*, *linux-mips64*, *linux-s390x*, *win-amd64*, *win-x86*,
-*darwin-x86_64* (MacOS X), *darwin-aarch64*, *freebsd-amd64*, and *freebsd-i386*.
+*darwin-x86_64* (MacOS X), *darwin-aarch64*, *freebsd-amd64*, and *freebsd-i386*,
+*linux-riscv64*.
 More builds will be available if I get access to more platforms.
 
 You can find published releases on Maven Central.

--- a/build.sbt
+++ b/build.sbt
@@ -174,6 +174,7 @@ Compile / packageBin / packageOptions ++= Seq(
       |linux/loongarch64/libzstd-jni-${version.value}.so;osname=Linux;processor=loongarch64,
       |linux/ppc64/libzstd-jni-${version.value}.so;osname=Linux;processor=ppc64,
       |linux/ppc64le/libzstd-jni-${version.value}.so;osname=Linux;processor=ppc64le,
+      |linux/riscv64/libzstd-jni-${version.value}.so;osname=Linux;processor=riscv64,
       |linux/s390x/libzstd-jni-${version.value}.so;osname=Linux;processor=s390x,
       |win/amd64/libzstd-jni-${version.value}.dll;osname=Win32;processor=amd64,
       |win/x86/libzstd-jni-${version.value}.dll;osname=Win32;processor=x86""".stripMargin}),
@@ -206,7 +207,8 @@ OsgiKeys.importPackage := Seq("org.osgi.framework;resolution:=optional")
 OsgiKeys.privatePackage := Seq(
     "linux.amd64", "linux.i386", "linux.aarch64", "linux.arm", "linux.ppc64",
     "linux.ppc64le", "linux.mips64", "linux.loongarch64", "linux.s390x", "darwin.x86_64",
-    "darwin.aarch64", "win.amd64", "win.x86", "freebsd.amd64", "freebsd.i386"
+    "darwin.aarch64", "win.amd64", "win.x86", "freebsd.amd64", "freebsd.i386",
+    "linux.riscv64"
 )
 // Explicitly specify the version of JavaSE required
 // (rather depend on figuring that out from the JDK it was built with)
@@ -324,6 +326,16 @@ Linux_s390x / packageBin / packageOptions ++= Seq(
   Package.ManifestAttributes(new java.util.jar.Attributes.Name("Automatic-Module-Name") -> "com.github.luben.zstd_jni"),
 )
 addArtifact(Artifact(nameValue, "linux_s390x"), Linux_s390x / packageBin)
+
+lazy val Linux_riscv64 = config("linux_riscv64").extend(Compile)
+inConfig(Linux_riscv64)(Defaults.compileSettings)
+Linux_riscv64 / packageBin / mappings := {
+  (file(s"target/classes/linux/riscv64/libzstd-jni-${version.value}.so"), s"linux/riscv64/libzstd-jni-${version.value}.so") :: classes
+}
+Linux_riscv64 / packageBin / packageOptions ++= Seq(
+  Package.ManifestAttributes(new java.util.jar.Attributes.Name("Automatic-Module-Name") -> "com.github.luben.zstd_jni"),
+)
+addArtifact(Artifact(nameValue, "linux_riscv64"), Linux_riscv64 / packageBin)
 
 /*
 lazy val Aix_ppc64 = config("aix_ppc64").extend(Compile)

--- a/make_so_cross.sh
+++ b/make_so_cross.sh
@@ -25,6 +25,7 @@ compile() {
     cp $BUILD_DIR/libzstd-jni-$VERSION.so $INSTALL
 }
 
+compile riscv64 "riscv64-linux-gnu-gcc -march=rv64gcv"
 compile arm arm-linux-gnueabihf-gcc
 compile s390x "s390x-linux-gnu-gcc -march=z196"
 #compile aarch64 aarch64-linux-gnu-gcc


### PR DESCRIPTION
Hi,
Can you take a look at this patch which try to bring basic riscv64 support to zstd-jni?
This patch is based on pr #281 , and pr #281 .

Thanks!

## Test
I have run the test via QEMU by following command:
```
CC=riscv64-linux-gnu-gcc ./sbt -java-home ~/jdk/build/linux-riscv64-server-release/images/jdk/ testOnly
```
There are lots of output, seems there is no error, and the bottom lines of output are:
```
[info] Total number of tests run: 151
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 151, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```