### PR TITLE
Remove -march for riscv

### DIFF
--- a/make_so_cross.sh
+++ b/make_so_cross.sh
@@ -25,7 +25,7 @@ compile() {
     cp $BUILD_DIR/libzstd-jni-$VERSION.so $INSTALL
 }
 
-compile riscv64 "riscv64-linux-gnu-gcc -march=rv64gcv"
+compile riscv64 "riscv64-linux-gnu-gcc"
 #compile arm arm-linux-gnueabihf-gcc
 #compile s390x "s390x-linux-gnu-gcc -march=z196"
 #compile aarch64 aarch64-linux-gnu-gcc


### PR DESCRIPTION
Hi,
Can you review this simple change?
It removes the `-march` argument when cross-compile riscv in make_so_cross.sh. This is to let the compiler to pick up the default arch, to enable most compatability on different hardwares.
Thanks!