### PR TITLE
Add new qemu platform for riscv64

### DIFF
--- a/.github/workflows/ci-qemu-cross.yml
+++ b/.github/workflows/ci-qemu-cross.yml
@@ -5,7 +5,8 @@ jobs:
         strategy:
             matrix:
                 include: [
-                    { platform: s390x }
+                    { platform: s390x },
+                    { platform: riscv64 },
                 ]
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
Hi,
Can you help to review this simple patch trying to [add riscv64 CI support](https://github.com/luben/zstd-jni/issues/284) in github?
Hope I'm doing it correctly.
Thanks!