### PR TITLE
ZstdInputStreamNoFinalizer / ZstdOutputStreamNoFinalizer may leak buf…

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -1531,10 +1531,15 @@ public class Zstd {
         }
     }
 
-    static final byte[] extractArray(ByteBuffer buffer) {
+    static ByteBuffer getArrayBackedBuffer(BufferPool bufferPool, int size) throws ZstdIOException {
+        ByteBuffer buffer = bufferPool.get(size);
+        if (buffer == null) {
+            throw new ZstdIOException(Zstd.errMemoryAllocation(), "Cannot get ByteBuffer of size " + size + " from the BufferPool");
+        }
         if (!buffer.hasArray() || buffer.arrayOffset() != 0) {
+            bufferPool.release(buffer);
             throw new IllegalArgumentException("provided ByteBuffer lacks array or has non-zero arrayOffset");
         }
-        return buffer.array();
+        return buffer;
     }
 }

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
@@ -80,11 +80,8 @@ public class ZstdOutputStreamNoFinalizer extends FilterOutputStream {
         // create compression context
         this.stream = createCStream();
         this.bufferPool = bufferPool;
-        this.dstByteBuffer = bufferPool.get(dstSize);
-        if (this.dstByteBuffer == null) {
-            throw new ZstdIOException(Zstd.errMemoryAllocation(), "Cannot get ByteBuffer of size " + dstSize + " from the BufferPool");
-        }
-        this.dst = Zstd.extractArray(dstByteBuffer);
+        this.dstByteBuffer = Zstd.getArrayBackedBuffer(bufferPool, dstSize);
+        this.dst = dstByteBuffer.array();
     }
 
     /**


### PR DESCRIPTION
…fers when these are not arrray based.

Motivation:

We need to put the buffers back in the pool in case of validation failure as otherwise the buffer will leak.

Modifications:

Handle validation and buffer lifecycle via a static helper method

Result:

No more leak possible