### PR TITLE
Add new constructor to ZstdDictCompress and ZstdDictDecompress

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
@@ -22,6 +22,13 @@ public class ZstdDictCompress extends SharedDictBase {
     private native void free();
 
     /**
+     * Get the byte buffer that backs this dict, if any, or null if not backed by a byte buffer.
+     */
+    public ByteBuffer getByReferenceBuffer() {
+	return sharedDict;
+    }
+
+    /**
      * Convenience constructor to create a new dictionary for use with fast compress
      *
      * @param dict  buffer containing dictionary to load/parse with exact length

--- a/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
@@ -20,6 +20,13 @@ public class ZstdDictDecompress extends SharedDictBase {
     private native void free();
 
     /**
+     * Get the byte buffer that backs this dict, if any, or null if not backed by a byte buffer.
+     */
+    public ByteBuffer getByReferenceBuffer() {
+	return sharedDict;
+    }
+
+    /**
      * Convenience constructor to create a new dictionary for use with fast decompress
      *
      * @param dict buffer containing dictionary to load/parse with exact length

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -32,17 +32,22 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictCompress_init
 /*
  * Class:     com_github_luben_zstd_ZstdDictCompress
  * Method:    init
- * Signature: (Ljava/nio/ByteBuffer;III)V
+ * Signature: (Ljava/nio/ByteBuffer;IIII)V
  */
 JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictCompress_initDirect
-  (JNIEnv *env, jobject obj, jobject dict, jint dict_offset, jint dict_size, jint level)
+  (JNIEnv *env, jobject obj, jobject dict, jint dict_offset, jint dict_size, jint level, jint byReference)
 {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     compress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "J");
     if (NULL == dict) return;
     void *dict_buff = (*env)->GetDirectBufferAddress(env, dict);
     if (NULL == dict_buff) return;
-    ZSTD_CDict* cdict = ZSTD_createCDict(((char *)dict_buff) + dict_offset, dict_size, level);
+    ZSTD_CDict* cdict = NULL;
+    if (byReference == 0) {
+      cdict = ZSTD_createCDict(((char *)dict_buff) + dict_offset, dict_size, level);
+    } else {
+      cdict = ZSTD_createCDict_byReference(((char *)dict_buff) + dict_offset, dict_size, level);
+    }
     if (NULL == cdict) return;
     (*env)->SetLongField(env, obj, compress_dict, (jlong)(intptr_t) cdict);
 }
@@ -85,17 +90,22 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictDecompress_init
 /*
  * Class:     com_github_luben_zstd_ZstdDictDecompress
  * Method:    initDirect
- * Signature: (Ljava/nio/ByteBuffer;II)V
+ * Signature: (Ljava/nio/ByteBuffer;III)V
  */
 JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictDecompress_initDirect
-  (JNIEnv *env, jobject obj, jobject dict, jint dict_offset, jint dict_size)
+  (JNIEnv *env, jobject obj, jobject dict, jint dict_offset, jint dict_size, jint byReference)
 {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     decompress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "J");
     if (NULL == dict) return;
     void *dict_buff = (*env)->GetDirectBufferAddress(env, dict);
 
-    ZSTD_DDict* ddict = ZSTD_createDDict(((char *)dict_buff) + dict_offset, dict_size);
+    ZSTD_DDict* ddict = NULL;
+    if (byReference == 0) {
+      ddict = ZSTD_createDDict(((char *)dict_buff) + dict_offset, dict_size);
+    } else {
+      ddict = ZSTD_createDDict_byReference(((char *)dict_buff) + dict_offset, dict_size);
+    }
 
     if (NULL == ddict) return;
     (*env)->SetLongField(env, obj, decompress_dict, (jlong)(intptr_t) ddict);

--- a/src/test/scala/ZstdDict.scala
+++ b/src/test/scala/ZstdDict.scala
@@ -104,17 +104,18 @@ class ZstdDictSpec extends AnyFlatSpec {
       assert(input.toSeq == decompressed.toSeq)
     }
 
-    it should s"round-trip compression/decompression ByteBuffers with fast dict at level $level with legacy $legacy" in {
+    it should s"round-trip compression/decompression ByteBuffers with fast dict at level $level with byReference $legacy" in {
+      val byReference = legacy // Reuse the variance flag here.
       val size = input.length
       val inBuf = ByteBuffer.allocateDirect(size)
       inBuf.put(input)
       inBuf.flip()
-      val cdict = new ZstdDictCompress(dictInDirectByteBuffer, level)
+      val cdict = new ZstdDictCompress(dictInDirectByteBuffer, level, byReference)
       val compressed = ByteBuffer.allocateDirect(Zstd.compressBound(size).toInt);
       Zstd.compress(compressed, inBuf, cdict)
       compressed.flip()
       cdict.close
-      val ddict = new ZstdDictDecompress(dictInDirectByteBuffer)
+      val ddict = new ZstdDictDecompress(dictInDirectByteBuffer, byReference)
       val decompressed = ByteBuffer.allocateDirect(size)
       Zstd.decompress(decompressed, compressed, ddict)
       decompressed.flip()


### PR DESCRIPTION
that allows the byReference semantics for the provided byte buffer: If you set this to true, you avoid the copying of the dict data into a natively malloc'ed buffer, but then also have to promise that the byte buffer will not be modified before the CTX has been closed.