### PR TITLE
Fix missing native free of Dict

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
@@ -95,7 +95,7 @@ public class ZstdDictCompress extends SharedDictBase {
            throw new IllegalStateException("ZSTD_createCDict failed");
         }
 	if (byReference) {
-	    sharedDict = dict; // ensures the dict is not garbage collected while this object remains, and flags that we should not use native free.
+	    sharedDict = dict; // ensures the dict is not garbage collected while this object remains.
 	}
         // Ensures that even if ZstdDictCompress is created and published through a race, no thread could observe
         // nativePtr == 0.
@@ -110,12 +110,9 @@ public class ZstdDictCompress extends SharedDictBase {
     @Override
     void  doClose() {
         if (nativePtr != 0) {
-	    if (sharedDict == null) {
-                free();
-	    } else {
-		sharedDict = null;
-	    }
+            free();
             nativePtr = 0;
+            sharedDict = null;
         }
     }
 }

--- a/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
@@ -86,7 +86,7 @@ public class ZstdDictDecompress extends SharedDictBase {
            throw new IllegalStateException("ZSTD_createDDict failed");
         }
 	if (byReference) {
-	    sharedDict = dict; // ensures the dict is not garbage collected while this object remains, and flags that we should not use native free.
+	    sharedDict = dict; // ensures the dict is not garbage collected while this object remains
 	}
         // Ensures that even if ZstdDictDecompress is created and published through a race, no thread could observe
         // nativePtr == 0.
@@ -97,12 +97,9 @@ public class ZstdDictDecompress extends SharedDictBase {
     @Override
      void doClose() {
         if (nativePtr != 0) {
-	    if (sharedDict == null) {
-                free();
-	    } else {
-		sharedDict = null;
-	    }
+            free();
             nativePtr = 0;
+            sharedDict = null;
         }
     }
 }


### PR DESCRIPTION
Even when using a by-reference buffer, the dict struct itself is malloc'ed and thus needs freeing to not leak memory.

The leak is fairly slow, as it leaks the size of the `struct ZSTD_CDict_s` (and  `ZSTD_DDict_s` for decompress) on every use, which takes quite a few rounds to become visible as an increase in overall process size.

The issue affects exclusively uses of the (new in v1.5.6-2) `getByReferenceBuffer` variants.
I would like to request a version bump and a new published build to allow using this downstream.

Fixes: https://github.com/luben/zstd-jni/issues/310