### PR TITLE
Show better error message, when the src/dst offset is negative

### DIFF
--- a/src/main/java/com/github/luben/zstd/Objects.java
+++ b/src/main/java/com/github/luben/zstd/Objects.java
@@ -1,0 +1,13 @@
+package com.github.luben.zstd;
+
+final class Objects {
+
+    /**
+     * Checks constraints, that the fromIndex, size, length is not negative, and fromIndex + size is not greater than the size. 
+     */
+    static void checkFromIndexSize(int fromIndex, int size, int length) {
+        if ((length | fromIndex | size) < 0 || size > length - fromIndex) {
+            throw new IndexOutOfBoundsException(String.format("Range [%s, %<s + %s) out of bounds for length %s", fromIndex, size, length));
+        }
+    }
+}

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -5,7 +5,6 @@ import com.github.luben.zstd.ZstdDictCompress;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Objects;
 
 public class ZstdCompressCtx extends AutoCloseBase {
 

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -5,6 +5,7 @@ import com.github.luben.zstd.ZstdDictCompress;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class ZstdCompressCtx extends AutoCloseBase {
 
@@ -525,6 +526,8 @@ public class ZstdCompressCtx extends AutoCloseBase {
         if (!dstBuff.isDirect()) {
             throw new IllegalArgumentException("dstBuff must be a direct buffer");
         }
+        Objects.checkFromIndexSize(srcOffset, srcSize, srcBuff.limit());
+        Objects.checkFromIndexSize(dstOffset, dstSize, dstBuff.limit());
 
         acquireSharedLock();
 
@@ -560,6 +563,9 @@ public class ZstdCompressCtx extends AutoCloseBase {
      * @return  the number of bytes written into buffer 'dstBuff'.
      */
     public int compressByteArray(byte[] dstBuff, int dstOffset, int dstSize, byte[] srcBuff, int srcOffset, int srcSize) {
+        Objects.checkFromIndexSize(srcOffset, srcSize, srcBuff.length);
+        Objects.checkFromIndexSize(dstOffset, dstSize, dstBuff.length);
+
         ensureOpen();
         acquireSharedLock();
 

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -5,7 +5,6 @@ import com.github.luben.zstd.ZstdDictDecompress;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Objects;
 
 public class ZstdDecompressCtx extends AutoCloseBase {
 

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -5,6 +5,7 @@ import com.github.luben.zstd.ZstdDictDecompress;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class ZstdDecompressCtx extends AutoCloseBase {
 
@@ -163,6 +164,8 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         if (!dstBuff.isDirect()) {
             throw new IllegalArgumentException("dstBuff must be a direct buffer");
         }
+        Objects.checkFromIndexSize(srcOffset, srcSize, srcBuff.limit());
+        Objects.checkFromIndexSize(dstOffset, dstSize, dstBuff.limit());
 
         acquireSharedLock();
 
@@ -196,6 +199,9 @@ public class ZstdDecompressCtx extends AutoCloseBase {
      * @return the number of bytes decompressed into destination buffer (originalSize)
      */
     public int decompressByteArray(byte[] dstBuff, int dstOffset, int dstSize, byte[] srcBuff, int srcOffset, int srcSize) {
+        Objects.checkFromIndexSize(srcOffset, srcSize, srcBuff.length);
+        Objects.checkFromIndexSize(dstOffset, dstSize, dstBuff.length);
+
         ensureOpen();
         acquireSharedLock();
 


### PR DESCRIPTION
Sorry, somehow I closed my previous PR when I tried to force push my new version.

So, checking the offset/size is easy in the Java side, if it's allowed to raise the Java language version to 11 - the Objects.checkFromIndexSize introduced after 8, so otherwise the compiler complains