### PR TITLE
Support decompression from byte array to ByteBuffer and vice-versa

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -418,6 +418,15 @@ public class Zstd {
         }
     }
 
+    public static int decompress(byte[] dst, ByteBuffer srcBuf) {
+        ZstdDecompressCtx ctx = new ZstdDecompressCtx();
+        try {
+            return ctx.decompress(dst, srcBuf);
+        } finally {
+            ctx.close();
+        }
+    }
+
     /**
      * Decompresses buffer 'src' into buffer 'dst'.
      *
@@ -1338,6 +1347,15 @@ public class Zstd {
         ZstdDecompressCtx ctx = new ZstdDecompressCtx();
         try {
             return ctx.decompress(dstBuf, srcBuf);
+        } finally {
+            ctx.close();
+        }
+    }
+
+    public static int decompress(ByteBuffer dstBuf, byte[] src) {
+        ZstdDecompressCtx ctx = new ZstdDecompressCtx();
+        try {
+            return ctx.decompress(dstBuf, src);
         } finally {
             ctx.close();
         }

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -311,11 +311,11 @@ public class ZstdDecompressCtx extends AutoCloseBase {
      */
     public int decompress(ByteBuffer dstBuf, ByteBuffer srcBuf) throws ZstdException {
         int size = decompressDirectByteBuffer(dstBuf,  // decompress into dstBuf
-            dstBuf.position(),                      // write decompressed data at offset position()
-            dstBuf.limit() - dstBuf.position(),     // write no more than limit() - position()
-            srcBuf,                                 // read compressed data from srcBuf
-            srcBuf.position(),                      // read starting at offset position()
-            srcBuf.limit() - srcBuf.position());    // read no more than limit() - position()
+                dstBuf.position(),                      // write decompressed data at offset position()
+                dstBuf.limit() - dstBuf.position(),     // write no more than limit() - position()
+                srcBuf,                                 // read compressed data from srcBuf
+                srcBuf.position(),                      // read starting at offset position()
+                srcBuf.limit() - srcBuf.position());    // read no more than limit() - position()
         srcBuf.position(srcBuf.limit());
         dstBuf.position(dstBuf.position() + size);
         return size;
@@ -323,22 +323,22 @@ public class ZstdDecompressCtx extends AutoCloseBase {
 
     public int decompress(ByteBuffer dstBuf, byte[] src) throws ZstdException {
         int size = decompressByteArrayToDirectByteBuffer(dstBuf,  // decompress into dstBuf
-            dstBuf.position(),                      // write decompressed data at offset position()
-            dstBuf.limit() - dstBuf.position(),     // write no more than limit() - position()
-            src,                                 // read compressed data from src
-            0,
-            src.length);
+                dstBuf.position(),                      // write decompressed data at offset position()
+                dstBuf.limit() - dstBuf.position(),     // write no more than limit() - position()
+                src,                                 // read compressed data from src
+                0,
+                src.length);
         dstBuf.position(dstBuf.position() + size);
         return size;
     }
 
     public int decompress(byte[] dst, ByteBuffer srcBuf) throws ZstdException {
         int size = decompressDirectByteBufferToByteArray(dst,  // decompress into dst
-            0,
-            dst.length,
-            srcBuf,                                 // read compressed data from srcBuf
-            srcBuf.position(),                      // read starting at offset position()
-            srcBuf.limit() - srcBuf.position());    // read no more than limit() - position()
+                0,
+                dst.length,
+                srcBuf,                                 // read compressed data from srcBuf
+                srcBuf.position(),                      // read starting at offset position()
+                srcBuf.limit() - srcBuf.position());    // read no more than limit() - position()
         srcBuf.position(srcBuf.limit());
         return size;
     }

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -744,10 +744,10 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressD
 
     ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
 
-    void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
-    if (dst_buff == NULL) goto E1;
     char *src_buff = (char*)(*env)->GetDirectBufferAddress(env, src);
     if (src_buff == NULL) return -ZSTD_error_memory_allocation;
+    void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
+    if (dst_buff == NULL) goto E1;
 
     ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
     size = ZSTD_decompressDCtx(dctx, ((char *)dst_buff) + dst_offset, (size_t) dst_size, ((char *)src_buff) + src_offset, (size_t) src_size);

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -86,13 +86,10 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
         val size = input.length
         val compressed = Zstd.compress(input, level)
 
-        val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size.toLong).toInt)
-        compressedBuffer.put(compressed)
-        compressedBuffer.limit(compressedBuffer.position())
-        compressedBuffer.flip()
-
-        val decompressedBuffer = Zstd.decompress(compressedBuffer, size)
-        val decompressed = new Array[Byte](size)
+        val decompressedBuffer = ByteBuffer.allocateDirect(size)
+        val decompressedSize = Zstd.decompress(decompressedBuffer, compressed);
+        val decompressed = new Array[Byte](decompressedSize)
+        decompressedBuffer.flip();
         decompressedBuffer.get(decompressed)
         input.toSeq == decompressed.toSeq
       }
@@ -104,11 +101,10 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
         val inputBuffer = ByteBuffer.allocateDirect(size)
         inputBuffer.put(input)
         inputBuffer.flip()
-        val compressedBuffer  = Zstd.compress(inputBuffer, level)
-        val compressed = new Array[Byte](compressedBuffer.limit() - compressedBuffer.position())
-        compressedBuffer.get(compressed)
+        val compressedBuffer = Zstd.compress(inputBuffer, level)
 
-        val decompressed = Zstd.decompress(compressed, size)
+        val decompressed = new Array[Byte](size)
+        Zstd.decompress(decompressed, compressedBuffer)
         input.toSeq == decompressed.toSeq
       }
     }


### PR DESCRIPTION
HBase uses zstd-jni for one implemention of its ZStandard support. I've been working on improving ZStandard decompression performance in HBase. My goal is to avoid copying data any more than absolutely necessary. In some situations, we have our compressed data in a byte array, and need to decompress into a direct ByteBuffer, or vice versa. This is not currently possible without an extra copy. In this PR, I expose the methods to accomplish this. My hope is that this PR gets accepted, and HBase can use the next version of zstd-jni to get a little performance boost.