### PR TITLE
Fix segmentation fault when calling ZstdOutputStream#setDict(ZstdDictCompress) with null

### DIFF
--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -286,6 +286,7 @@ E1:
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictCompress
   (JNIEnv *env, jclass obj, jlong stream, jobject dict) {
+    if (dict == NULL) return -ZSTD_error_dictionary_wrong;
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
     jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "J");
     ZSTD_CDict* cdict = (ZSTD_CDict*)(intptr_t)(*env)->GetLongField(env, dict, compress_dict);

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -918,6 +918,14 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
     }
   }
 
+  "ZstdOutputStream" should s"do not cause a segmentation fault" in {
+    val os  = new ByteArrayOutputStream(100)
+    val zos = new ZstdOutputStream(os)
+    assertThrows[ZstdIOException] {
+      zos.setDict(null.asInstanceOf[ZstdDictCompress])
+    }
+  }
+
   "ZstdDirectBufferCompressingStream" should s"do nothing on double close but throw on writing on closed stream" in {
     val os  = ByteBuffer.allocateDirect(100)
     val zos = new ZstdDirectBufferCompressingStream(os, 1)


### PR DESCRIPTION
Fix segmentation fault when calling ZstdOutputStream#setDict(ZstdDictCompress) with null

For example:
```
💣 Program crashed: Bad pointer dereference at 0x0000000000000000

Thread 73 "Java: pool-18-thread-15-ScalaTest-running-ZstdSpec" crashed:

 0 0x0000000103077460 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<1097844ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 1097844ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
 1 0x00000001031c495c jni_GetObjectClass + 184 in libjvm.dylib
 2 0x000000012800bbfc
 3 0x0000000128006ab0
 4 0x0000000128006ee0
 5 0x0000000128006ee0
 6 0x0000000128006ee0
 7 0x0000000128006fc8
 8 0x0000000128006ee0
 9 0x0000000128006ee0
10 0x0000000128006ee0
11 0x0000000128006ee0
12 0x0000000128006fc8
13 0x0000000128006fc8
14 0x0000000128006ee0
15 0x0000000128006ee0
16 0x0000000128006fc8
17 0x0000000128006ee0
18 0x0000000128006ee0
19 0x0000000128006fc8
20 0x0000000128006ee0
21 0x0000000128006ee0
22 0x0000000128006ee0
23 0x0000000128006fc8
24 0x0000000128006ee0
25 0x0000000128006fc8
26 0x0000000128006ee0
27 0x000000012b8e8680
28 0x000000012800719c
29 0x0000000128006ee0
30 0x0000000128006ee0
31 0x0000000128006fc8
32 0x000000012800719c
33 0x000000012800719c
34 0x0000000128006ee0
35 0x0000000128006ee0
36 0x0000000128006ee0
37 0x0000000128006ee0
38 0x0000000128006fc8
39 0x0000000128006ee0
40 0x0000000128006ee0
41 0x0000000128006fc8
42 0x0000000128006ee0
43 0x0000000128006fc8
44 0x0000000128006ee0
45 0x0000000128006ee0
46 0x0000000128006ee0
47 0x0000000128006fc8
48 0x0000000128006ee0
49 0x0000000128006fc8
50 0x0000000128006ee0
51 0x0000000128006ee0
52 0x0000000128006ee0
53 0x0000000128006fc8
54 0x0000000128006ee0
55 0x0000000128006ee0
56 0x0000000128006fc8
57 0x0000000128006ee0
58 0x0000000128006ee0
59 0x0000000128006ee0
60 0x0000000128006fc8
61 0x0000000128006ee0

Backtrace took 9.14s

>>> 
>>> quit
zsh: segmentation fault  sbt compile test package
```