### PR TITLE
Fix segmentation faults

### DIFF
--- a/src/main/native/jni_zdict.c
+++ b/src/main/native/jni_zdict.c
@@ -9,6 +9,7 @@
 
 JNIEXPORT jlong Java_com_github_luben_zstd_Zstd_trainFromBuffer0
   (JNIEnv *env, jclass obj, jobjectArray samples, jbyteArray dictBuffer, jboolean legacy, jint compressionLevel) {
+    if (dictBuffer == NULL) return -ZSTD_error_dictionary_wrong;
     size_t size = 0;
     jsize num_samples = (*env)->GetArrayLength(env, samples);
     size_t *samples_sizes = malloc(sizeof(size_t) * num_samples);

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -254,6 +254,7 @@ E1:
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictDecompress
   (JNIEnv *env, jclass obj, jlong stream, jobject dict) {
+    if (dict == NULL) return -ZSTD_error_dictionary_wrong;
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
     jfieldID decompress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "J");
     ZSTD_DDict* ddict = (ZSTD_DDict*)(intptr_t)(*env)->GetLongField(env, dict, decompress_dict);

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -237,6 +237,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_getErrorCode
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadDictDecompress
   (JNIEnv *env, jclass obj, jlong stream, jbyteArray dict, jint dict_size) {
+    if (dict == NULL) return -ZSTD_error_dictionary_wrong;
     size_t size = -ZSTD_error_memory_allocation;
     void *dict_buff = (*env)->GetPrimitiveArrayCritical(env, dict, NULL);
     if (dict_buff == NULL) goto E1;

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -271,6 +271,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictDecompress
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadDictCompress
   (JNIEnv *env, jclass obj, jlong stream, jbyteArray dict, jint dict_size) {
+    if (dict == NULL) return -ZSTD_error_dictionary_wrong;
     size_t size = -ZSTD_error_memory_allocation;
     void *dict_buff = (*env)->GetPrimitiveArrayCritical(env, dict, NULL);
     if (dict_buff == NULL) goto E1;

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -951,6 +951,21 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
     assert(Zstd.loadDictCompress(0, null , 0) == -32)
   }
 
+  "Zstd" should s"do not cause a segmentation fault in decompressedDirectByteBufferSize()" in {
+    assert(Zstd.decompressedDirectByteBufferSize(null, 0, 0) == -1)
+  }
+
+  "Zstd" should s"do not cause a segmentation fault in getDirectByteBufferFrameContentSize()" in {
+    assert(Zstd.getDirectByteBufferFrameContentSize(null, 0, 0) == -1)
+  }
+
+  "Zstd" should s"do not cause a segmentation fault in trainFromBuffer()" in {
+    // Avoid:
+    // 0 0x00000001039727c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
+    // 1 0x0000000103d257c0 jni_GetArrayLength + 164 in libjvm.dylib
+    assert(Zstd.trainFromBuffer(Array.fill(11, 0)(0), null, false, 0) == -32)
+  }
+
   "ZstdDirectBufferCompressingStream" should s"do nothing on double close but throw on writing on closed stream" in {
     val os  = ByteBuffer.allocateDirect(100)
     val zos = new ZstdDirectBufferCompressingStream(os, 1)

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -937,6 +937,13 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
     assert(Zstd.loadFastDictDecompress(0, null.asInstanceOf[ZstdDictDecompress]) == -32)
   }
 
+  "Zstd" should s"do not cause a segmentation fault in loadDictDecompress()" in {
+    // Avoid:
+    //  0 0x000000010185e7c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
+    // 1 0x0000000101c17ca8 jni_GetPrimitiveArrayCritical + 340 in libjvm.dylib
+    assert(Zstd.loadDictDecompress(0, null , 0) == -32)
+  }
+
   "ZstdDirectBufferCompressingStream" should s"do nothing on double close but throw on writing on closed stream" in {
     val os  = ByteBuffer.allocateDirect(100)
     val zos = new ZstdDirectBufferCompressingStream(os, 1)

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -932,16 +932,23 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
       zin.setDict(null.asInstanceOf[ZstdDictDecompress])
     }
     // Avoid:
-    //  0 0x0000000103a067c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
-    //  1 0x0000000103daa0f8 jni_GetObjectClass + 184 in libjvm.dylib
+    // 0 0x0000000103a067c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
+    // 1 0x0000000103daa0f8 jni_GetObjectClass + 184 in libjvm.dylib
     assert(Zstd.loadFastDictDecompress(0, null.asInstanceOf[ZstdDictDecompress]) == -32)
   }
 
   "Zstd" should s"do not cause a segmentation fault in loadDictDecompress()" in {
     // Avoid:
-    //  0 0x000000010185e7c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
+    // 0 0x000000010185e7c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
     // 1 0x0000000101c17ca8 jni_GetPrimitiveArrayCritical + 340 in libjvm.dylib
     assert(Zstd.loadDictDecompress(0, null , 0) == -32)
+  }
+
+  "Zstd" should s"do not cause a segmentation fault in loadDictCompress()" in {
+    // Avoid:
+    // 0 0x000000010152a7c8 AccessInternal::PostRuntimeDispatch<G1BarrierSet::AccessBarrier<548964ull, G1BarrierSet>, (AccessInternal::BarrierType)2, 548964ull>::oop_access_barrier(void*) + 8 in libjvm.dylib
+    // 1 0x00000001018e3ca8 jni_GetPrimitiveArrayCritical + 340 in libjvm.dylib
+    assert(Zstd.loadDictCompress(0, null , 0) == -32)
   }
 
   "ZstdDirectBufferCompressingStream" should s"do nothing on double close but throw on writing on closed stream" in {


### PR DESCRIPTION
Fix segmentation faults in:

- Java_com_github_luben_zstd_Zstd_trainFromBuffer0
- Java_com_github_luben_zstd_Zstd_loadDictDecompress
- Java_com_github_luben_zstd_Zstd_loadFastDictDecompress
- Java_com_github_luben_zstd_Zstd_loadDictCompress