### PR TITLE
fix: compress & decompress DirectByteBufferStream error is always ZSTD_error_no_error

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -502,7 +502,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         try {
             long result = compressDirectByteBufferStream0(nativePtr, dst, dst.position(), dst.limit(), src, src.position(), src.limit(), endOp.value());
             if ((result & 0x80000000L) != 0) {
-                long code = result & 0xFF;
+                long code = -(result & 0xFF);
                 throw new ZstdException(code, Zstd.getErrorName(code));
             }
             src.position((int)(result & 0x7FFFFFFF));

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -137,7 +137,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         try {
             long result = decompressDirectByteBufferStream0(nativePtr, dst, dst.position(), dst.limit(), src, src.position(), src.limit());
             if ((result & 0x80000000L) != 0) {
-                long code = result & 0xFF;
+                long code = -(result & 0xFF);
                 throw new ZstdException(code, Zstd.getErrorName(code));
             }
             src.position((int) (result & 0x7FFFFFFF));

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -1486,7 +1486,8 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
             cctx.compressDirectByteBufferStream(compressedBuffer, inputBuffer, EndDirective.END)
             fail("compression succeeded, but should have failed")
           } catch {
-            case _: ZstdException =>  // compression should throw a ZstdException
+            case ex: ZstdException =>  // compression should throw a ZstdException
+                assert(ex.getErrorCode == -106)
           }
         }
       }


### PR DESCRIPTION
"result & 0xFF" always yields a positive number, but ZstdErrorCode needs negative number.