### PR TITLE
fix: ZstdInputStream decompression failure when underlying stream returns 0 then -1 at frame boundary

### DIFF
--- a/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
@@ -173,8 +173,11 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
                     } else {
                         throw new ZstdIOException(Zstd.errCorruptionDetected(), "Truncated source");
                     }
+                } else if (srcSize == 0) {
+                    continue;
+                } else {
+                    frameFinished = false;
                 }
-                frameFinished = false;
             }
 
             lastDstPos = dstPos;


### PR DESCRIPTION
  ## Summary
  - Fix decompression failure when underlying InputStream returns 0 (no data available) followed by -1 (EOF) at a frame boundary
  - The bug caused `frameFinished` to remain `false` even when a frame was complete, leading to "Truncated source" error
  - Only set `frameFinished = false` when actually reading data (srcSize > 0), and skip when srcSize == 0

  ## Test plan
  - Added test: underlying stream returning 0 then -1 mid-frame (should throw ZstdIOException for truncated data)
  - Added test: underlying stream returning 0 then data then -1 mid-frame (should succeed)
  - Added test: underlying stream returning 0 then -1 at frame boundary (should succeed and return -1 on subsequent reads)
