### PR TITLE
Avoid SetLongField call when GetPrimitiveArrayCritical return NULL

### DIFF
--- a/src/main/native/jni_outputstream_zstd.c
+++ b/src/main/native/jni_outputstream_zstd.c
@@ -72,14 +72,12 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_co
 
     size = ZSTD_compressStream2((ZSTD_CStream *)(intptr_t) stream, &output, &input, ZSTD_e_continue);
 
-    (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
     (*env)->SetLongField(env, obj, src_pos_id, input.pos);
     (*env)->SetLongField(env, obj, dst_pos_id, output.pos);
-E1: return (jint) size;
-
+    (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
 E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
-    goto E1;
+
+E1: return (jint) size;
 }
 
 /*


### PR DESCRIPTION
When src_buff == NULL, there is no need to call SetLongField

```c
    void *src_buff = (*env)->GetPrimitiveArrayCritical(env, src, NULL);
    if (src_buff == NULL) goto E2;


E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
    (*env)->SetLongField(env, obj, src_pos_id, input.pos);
    (*env)->SetLongField(env, obj, dst_pos_id, output.pos);
```