### PR TITLE
Decompression-bomb hardening: bounded getFrameContentSize + security docs

### DIFF
--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -718,6 +718,12 @@ public class Zstd {
     /**
      * Return the original size of a compressed buffer (if known)
      *
+     * <p><b>Security note:</b> the returned value is read directly from the frame header and is
+     * therefore untrusted and fully attacker-controlled &mdash; a tiny frame can declare a
+     * multi-gigabyte size (the field is up to 8 bytes wide). Never size an output buffer directly
+     * from this value; validate it against an application-defined limit first, or use
+     * {@link #getFrameContentSizeBounded(byte[], long)}.
+     *
      * @param src the compressed buffer
      * @param srcPosition offset of the compressed data inside the src buffer
      * @param srcSize length of the compressed data inside the src buffer
@@ -831,6 +837,31 @@ public class Zstd {
      */
     public static long getFrameContentSize(byte[] src) {
         return getFrameContentSize(src, 0);
+    }
+
+    /**
+     * Bounded variant of {@link #getFrameContentSize(byte[])} that guards against decompression
+     * bombs. The frame content size is read from the (untrusted, attacker-controlled) frame header,
+     * so callers that pre-allocate an output buffer from it must reject oversized declarations.
+     * This returns the declared size only when it does not exceed {@code maxSize}, and throws
+     * otherwise instead of letting a crafted header drive an attacker-chosen allocation.
+     *
+     * @param src     the compressed buffer
+     * @param maxSize the largest content size to accept, in bytes
+     * @return the declared content size in bytes (0 if the size is not stored in the frame)
+     * @throws ZstdException if the frame header cannot be decoded, or it declares a size
+     *                       larger than {@code maxSize}
+     */
+    public static long getFrameContentSizeBounded(byte[] src, long maxSize) {
+        long size = getFrameContentSize(src);
+        if (size < 0) {
+            throw new ZstdException(Zstd.errGeneric(), "Could not read the zstd frame content size");
+        }
+        if (size > maxSize) {
+            throw new ZstdException(Zstd.errGeneric(),
+                "Declared frame content size (" + size + " bytes) exceeds the allowed maximum (" + maxSize + " bytes)");
+        }
+        return size;
     }
 
     /**

--- a/src/main/java/com/github/luben/zstd/ZstdInputStream.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStream.java
@@ -83,6 +83,21 @@ public class ZstdInputStream extends FilterInputStream {
         return this;
     }
 
+    /**
+     * Set the maximum back-reference window the decoder may use, as a base-2 log
+     * (ZSTD_d_windowLogMax). The default is 27, i.e. a 128&nbsp;MiB window.
+     *
+     * <p>The window size is taken from the (untrusted) frame header and a native buffer of that
+     * size is allocated while the header is parsed &mdash; before any output is produced &mdash; so
+     * a hostile frame can force an allocation of up to {@code 1 << windowLogMax} from only a few
+     * bytes of input. When decoding untrusted data, set this <i>lower</i> than the default (to the
+     * largest window you legitimately expect) to bound that allocation; raise it only when you must
+     * accept large / long-distance-matching windows.
+     *
+     * @param windowLogMax base-2 log of the maximum allowed window size
+     * @return this stream
+     * @throws IOException if the parameter is rejected by the decoder
+     */
     public ZstdInputStream setLongMax(int windowLogMax) throws IOException {
         inner.setLongMax(windowLogMax);
         return this;

--- a/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
@@ -111,6 +111,21 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
         return this;
     }
 
+    /**
+     * Set the maximum back-reference window the decoder may use, as a base-2 log
+     * (ZSTD_d_windowLogMax). The default is 27, i.e. a 128&nbsp;MiB window.
+     *
+     * <p>The window size is taken from the (untrusted) frame header and a native buffer of that
+     * size is allocated while the header is parsed &mdash; before any output is produced &mdash; so
+     * a hostile frame can force an allocation of up to {@code 1 << windowLogMax} from only a few
+     * bytes of input. When decoding untrusted data, set this <i>lower</i> than the default (to the
+     * largest window you legitimately expect) to bound that allocation; raise it only when you must
+     * accept large / long-distance-matching windows.
+     *
+     * @param windowLogMax base-2 log of the maximum allowed window size
+     * @return this stream
+     * @throws IOException if the parameter is rejected by the decoder
+     */
     public synchronized ZstdInputStreamNoFinalizer setLongMax(int windowLogMax) throws IOException {
         int size = Zstd.setDecompressionLongMax(stream, windowLogMax);
         if (Zstd.isError(size)) {


### PR DESCRIPTION
## Decompression-bomb hardening (docs + one opt-in helper, no behavior change)

The frame header carries size fields that are read before any data is decoded, so a caller that
pre-allocates from them should bound the values first. This PR makes the safe path easier to reach
and documents the trust boundary; it changes no existing behavior.

- **`Zstd.getFrameContentSizeBounded(byte[] src, long maxSize)`** — returns the declared content
  size only when it does not exceed `maxSize`, otherwise throws. Named distinctly to avoid an
  overload clash with the existing `getFrameContentSize(byte[] src, int srcPosition)`.
- **Javadoc** on `getFrameContentSize()` / `decompressedSize()`: the returned value comes from an
  untrusted header and should be bounded before it is used to size a buffer.
- **Javadoc** on `ZstdInputStream` / `ZstdInputStreamNoFinalizer` `setLongMax()`: it sets
  `ZSTD_d_windowLogMax` (default 27) and can be set **lower** to bound the window when decoding
  untrusted input.

No API is removed or changed; the new method is additive and opt-in. Happy to adjust naming or
scope (e.g. docs-only) to your preference.
