### PR TITLE
Support heap buffers in streaming compression

### DIFF
--- a/src/main/java/com/github/luben/zstd/EndDirective.java
+++ b/src/main/java/com/github/luben/zstd/EndDirective.java
@@ -2,6 +2,7 @@ package com.github.luben.zstd;
 
 /** Enum that expresses desired flushing for a streaming compression call.
  *
+ * @see ZstdCompressCtx#compressByteBufferStream
  * @see ZstdCompressCtx#compressDirectByteBufferStream
  */
 public enum EndDirective {

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -520,6 +520,63 @@ public class ZstdCompressCtx extends AutoCloseBase {
 
     /**
      * Compress as much of the <code>src</code> {@link ByteBuffer} into the <code>dst</code> {@link
+     * ByteBuffer} as possible. Both buffers may be direct or array-backed heap buffers. The
+     * destination buffer must be writable.
+     *
+     * @param dst destination of compressed data
+     * @param src buffer to compress
+     * @param endOp directive for handling the end of the stream
+     * @return true if all state has been flushed from internal buffers
+     * @throws IllegalArgumentException if either buffer is unsupported or the destination is read-only
+     */
+    public boolean compressByteBufferStream(@NotNull ByteBuffer dst, @NotNull ByteBuffer src, @NotNull EndDirective endOp) {
+        ensureOpen();
+        if (dst.isReadOnly()) {
+            throw new IllegalArgumentException("dst must be writable");
+        }
+        if (!dst.isDirect() && !dst.hasArray()) {
+            throw new IllegalArgumentException("dst must be a direct or array-backed buffer");
+        }
+        if (!src.isDirect() && !src.hasArray()) {
+            throw new IllegalArgumentException("src must be a direct or array-backed buffer");
+        }
+
+        acquireSharedLock();
+        try {
+            final long result;
+            if (dst.isDirect()) {
+                if (src.isDirect()) {
+                    result = compressDirectByteBufferStream0(nativePtr, dst, dst.position(), dst.limit(), src,
+                            src.position(), src.limit(), endOp.value());
+                } else {
+                    result = compressByteArrayToDirectByteBufferStream0(nativePtr, dst, dst.position(), dst.limit(),
+                            src.array(), src.arrayOffset(), src.position(), src.limit(), endOp.value());
+                }
+            } else if (src.isDirect()) {
+                result = compressDirectByteBufferToByteArrayStream0(nativePtr, dst.array(), dst.arrayOffset(),
+                        dst.position(), dst.limit(), src, src.position(), src.limit(), endOp.value());
+            } else {
+                result = compressByteArrayStream0(nativePtr, dst.array(), dst.arrayOffset(), dst.position(), dst.limit(),
+                        src.array(), src.arrayOffset(), src.position(), src.limit(), endOp.value());
+            }
+            return updateStreamPositions(result, dst, src);
+        } finally {
+            releaseSharedLock();
+        }
+    }
+
+    private static native long compressByteArrayToDirectByteBufferStream0(long ptr, @NotNull ByteBuffer dst,
+            int dstOffset, int dstSize, byte @NotNull [] src, int srcArrayOffset, int srcOffset, int srcSize, int endOp);
+
+    private static native long compressDirectByteBufferToByteArrayStream0(long ptr, byte @NotNull [] dst,
+            int dstArrayOffset, int dstOffset, int dstSize, @NotNull ByteBuffer src, int srcOffset, int srcSize, int endOp);
+
+    private static native long compressByteArrayStream0(long ptr, byte @NotNull [] dst, int dstArrayOffset,
+            int dstOffset, int dstSize,
+            byte @NotNull [] src, int srcArrayOffset, int srcOffset, int srcSize, int endOp);
+
+    /**
+     * Compress as much of the <code>src</code> {@link ByteBuffer} into the <code>dst</code> {@link
      * ByteBuffer} as possible.
      *
      * @param dst destination of compressed data
@@ -532,13 +589,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         acquireSharedLock();
         try {
             long result = compressDirectByteBufferStream0(nativePtr, dst, dst.position(), dst.limit(), src, src.position(), src.limit(), endOp.value());
-            if ((result & 0x80000000L) != 0) {
-                long code = -(result & 0xFF);
-                throw new ZstdException(code, Zstd.getErrorName(code));
-            }
-            src.position((int)(result & 0x7FFFFFFF));
-            dst.position((int)(result >>> 32) & 0x7FFFFFFF);
-            return (result >>> 63) == 1;
+            return updateStreamPositions(result, dst, src);
         } finally {
             releaseSharedLock();
         }
@@ -551,7 +602,18 @@ public class ZstdCompressCtx extends AutoCloseBase {
      * bit is set if an error occurred. If an error occurred, the lowest 31 bits encode a zstd error
      * code. Otherwise, the lowest 31 bits are the new position of the source buffer.
      */
-    private static native long compressDirectByteBufferStream0(long ptr, @NotNull ByteBuffer dst, int dstOffset, int dstSize, @NotNull ByteBuffer src, int srcSize, int srcOffset, int endOp);
+    private static native long compressDirectByteBufferStream0(long ptr, @NotNull ByteBuffer dst, int dstOffset, int dstSize,
+            @NotNull ByteBuffer src, int srcOffset, int srcSize, int endOp);
+
+    private static boolean updateStreamPositions(long result, @NotNull ByteBuffer dst, @NotNull ByteBuffer src) {
+        if ((result & 0x80000000L) != 0) {
+            long code = -(result & 0xFF);
+            throw new ZstdException(code, Zstd.getErrorName(code));
+        }
+        src.position((int)(result & 0x7FFFFFFF));
+        dst.position((int)(result >>> 32) & 0x7FFFFFFF);
+        return (result >>> 63) == 1;
+    }
 
     /**
      * Compresses buffer 'srcBuff' into buffer 'dstBuff' reusing this ZstdCompressCtx.

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -389,34 +389,142 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_setPledgedSrc
     return ZSTD_CCtx_setPledgedSrcSize(cctx, (unsigned long long)src_size);
 }
 
+static size_t validate_compress_stream_bounds
+  (jint dst_offset, jint dst_size, jint src_offset, jint src_size) {
+    if (0 > dst_offset || dst_offset > dst_size) return -ZSTD_error_dstSize_tooSmall;
+    if (0 > src_offset || src_offset > src_size) return -ZSTD_error_srcSize_wrong;
+    return 0;
+}
+
+static int is_valid_array_stream_buffer
+  (JNIEnv *env, jbyteArray buffer, jint array_offset, jint size) {
+    if (0 > array_offset || 0 > size) return 0;
+    jsize capacity = (*env)->GetArrayLength(env, buffer);
+    return array_offset <= capacity && size <= capacity - array_offset;
+}
+
+static size_t compress_buffer_stream
+  (jlong ptr, void *dst, jint *dst_offset, jint dst_size, const void *src, jint *src_offset, jint src_size, jint end_op) {
+    ZSTD_outBuffer out;
+    out.pos = *dst_offset;
+    out.size = dst_size;
+    out.dst = dst;
+
+    ZSTD_inBuffer in;
+    in.pos = *src_offset;
+    in.size = src_size;
+    in.src = src;
+
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    size_t result = ZSTD_compressStream2(cctx, &out, &in, end_op);
+    *dst_offset = out.pos;
+    *src_offset = in.pos;
+    return result;
+}
+
+static jlong encode_compress_stream_result
+  (size_t result, jint dst_offset, jint src_offset) {
+    if (ZSTD_isError(result)) {
+        return (1ULL << 31) | ZSTD_getErrorCode(result);
+    }
+    jlong encoded_result = ((jlong)dst_offset << 32) | src_offset;
+    if (result == 0) {
+        encoded_result |= 1ULL << 63;
+    }
+    return encoded_result;
+}
+
 static size_t compress_direct_buffer_stream
-  (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size, jint end_op) {
+  (JNIEnv *env, jlong ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size,
+   jint end_op) {
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;
-    if (0 > *dst_offset) return -ZSTD_error_dstSize_tooSmall;
-    if (0 > *src_offset) return -ZSTD_error_srcSize_wrong;
-    if (0 > src_size) return -ZSTD_error_srcSize_wrong;
+    size_t result = validate_compress_stream_bounds(*dst_offset, dst_size, *src_offset, src_size);
+    if (ZSTD_isError(result)) return result;
 
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst);
     if (dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
     if (src_size > src_cap) return -ZSTD_error_srcSize_wrong;
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
 
-    ZSTD_outBuffer out;
-    out.pos = *dst_offset;
-    out.size = dst_size;
-    out.dst = (*env)->GetDirectBufferAddress(env, dst);
-    if (out.dst == NULL) return -ZSTD_error_memory_allocation;
-    ZSTD_inBuffer in;
-    in.pos = *src_offset;
-    in.size = src_size;
-    in.src = (*env)->GetDirectBufferAddress(env, src);
-    if (in.src == NULL) return -ZSTD_error_memory_allocation;
+    void *dst_buff = (*env)->GetDirectBufferAddress(env, dst);
+    if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
+    void *src_buff = (*env)->GetDirectBufferAddress(env, src);
+    if (src_buff == NULL) return -ZSTD_error_memory_allocation;
 
-    size_t result = ZSTD_compressStream2(cctx, &out, &in, end_op);
-    *dst_offset = out.pos;
-    *src_offset = in.pos;
+    return compress_buffer_stream(ptr, dst_buff, dst_offset, dst_size, src_buff, src_offset, src_size, end_op);
+}
+
+static size_t compress_byte_array_to_direct_buffer_stream
+  (JNIEnv *env, jlong ptr, jobject dst, jint *dst_offset, jint dst_size, jbyteArray src, jint src_array_offset,
+   jint *src_offset, jint src_size, jint end_op) {
+    if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
+    if (NULL == src) return -ZSTD_error_srcSize_wrong;
+    size_t result = validate_compress_stream_bounds(*dst_offset, dst_size, *src_offset, src_size);
+    if (ZSTD_isError(result)) return result;
+
+    jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst);
+    if (dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
+    if (!is_valid_array_stream_buffer(env, src, src_array_offset, src_size)) return -ZSTD_error_srcSize_wrong;
+
+    void *dst_buff = (*env)->GetDirectBufferAddress(env, dst);
+    if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
+    void *src_buff = (*env)->GetPrimitiveArrayCritical(env, src, NULL);
+    if (src_buff == NULL) return -ZSTD_error_memory_allocation;
+
+    result = compress_buffer_stream(ptr, dst_buff, dst_offset, dst_size, ((char *)src_buff) + src_array_offset,
+                                    src_offset, src_size, end_op);
+    (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
+    return result;
+}
+
+static size_t compress_direct_buffer_to_byte_array_stream
+  (JNIEnv *env, jlong ptr, jbyteArray dst, jint dst_array_offset, jint *dst_offset, jint dst_size, jobject src,
+   jint *src_offset, jint src_size, jint end_op) {
+    if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
+    if (NULL == src) return -ZSTD_error_srcSize_wrong;
+    size_t result = validate_compress_stream_bounds(*dst_offset, dst_size, *src_offset, src_size);
+    if (ZSTD_isError(result)) return result;
+
+    if (!is_valid_array_stream_buffer(env, dst, dst_array_offset, dst_size)) return -ZSTD_error_dstSize_tooSmall;
+    jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
+    if (src_size > src_cap) return -ZSTD_error_srcSize_wrong;
+
+    void *src_buff = (*env)->GetDirectBufferAddress(env, src);
+    if (src_buff == NULL) return -ZSTD_error_memory_allocation;
+    void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
+    if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
+
+    result = compress_buffer_stream(ptr, ((char *)dst_buff) + dst_array_offset, dst_offset, dst_size, src_buff,
+                                    src_offset, src_size, end_op);
+    (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
+    return result;
+}
+
+static size_t compress_byte_array_stream
+  (JNIEnv *env, jlong ptr, jbyteArray dst, jint dst_array_offset, jint *dst_offset, jint dst_size, jbyteArray src,
+   jint src_array_offset, jint *src_offset, jint src_size, jint end_op) {
+    if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
+    if (NULL == src) return -ZSTD_error_srcSize_wrong;
+    size_t result = validate_compress_stream_bounds(*dst_offset, dst_size, *src_offset, src_size);
+    if (ZSTD_isError(result)) return result;
+
+    if (!is_valid_array_stream_buffer(env, dst, dst_array_offset, dst_size)) return -ZSTD_error_dstSize_tooSmall;
+    if (!is_valid_array_stream_buffer(env, src, src_array_offset, src_size)) return -ZSTD_error_srcSize_wrong;
+
+    /* Avoid nested critical regions when both buffers are heap arrays. */
+    jbyte *dst_buff = (*env)->GetByteArrayElements(env, dst, NULL);
+    if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
+    jbyte *src_buff = (*env)->GetByteArrayElements(env, src, NULL);
+    if (src_buff == NULL) {
+        (*env)->ReleaseByteArrayElements(env, dst, dst_buff, JNI_ABORT);
+        return -ZSTD_error_memory_allocation;
+    }
+
+    result = compress_buffer_stream(ptr, ((char *)dst_buff) + dst_array_offset, dst_offset, dst_size,
+                                    ((char *)src_buff) + src_array_offset, src_offset, src_size, end_op);
+    (*env)->ReleaseByteArrayElements(env, src, src_buff, JNI_ABORT);
+    (*env)->ReleaseByteArrayElements(env, dst, dst_buff, 0);
     return result;
 }
 
@@ -427,15 +535,47 @@ static size_t compress_direct_buffer_stream
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirectByteBufferStream0
   (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size, jint end_op) {
-    size_t result = compress_direct_buffer_stream(env, jctx, ptr, dst, &dst_offset, dst_size, src, &src_offset, src_size, end_op);
-    if (ZSTD_isError(result)) {
-        return (1ULL << 31) | ZSTD_getErrorCode(result);
-    }
-    jlong encoded_result = ((jlong)dst_offset << 32) | src_offset;
-    if (result == 0) {
-        encoded_result |= 1ULL << 63;
-    }
-    return encoded_result;
+    size_t result = compress_direct_buffer_stream(env, ptr, dst, &dst_offset, dst_size, src, &src_offset, src_size, end_op);
+    return encode_compress_stream_result(result, dst_offset, src_offset);
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdCompressCtx
+ * Method:    compressByteArrayToDirectByteBufferStream0
+ * Signature: (JLjava/nio/ByteBuffer;II[BIIII)J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressByteArrayToDirectByteBufferStream0
+  (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jbyteArray src,
+   jint src_array_offset, jint src_offset, jint src_size, jint end_op) {
+    size_t result = compress_byte_array_to_direct_buffer_stream(env, ptr, dst, &dst_offset, dst_size, src,
+                                                                src_array_offset, &src_offset, src_size, end_op);
+    return encode_compress_stream_result(result, dst_offset, src_offset);
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdCompressCtx
+ * Method:    compressDirectByteBufferToByteArrayStream0
+ * Signature: (J[BIIILjava/nio/ByteBuffer;III)J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirectByteBufferToByteArrayStream0
+  (JNIEnv *env, jclass jctx, jlong ptr, jbyteArray dst, jint dst_array_offset, jint dst_offset, jint dst_size,
+   jobject src, jint src_offset, jint src_size, jint end_op) {
+    size_t result = compress_direct_buffer_to_byte_array_stream(env, ptr, dst, dst_array_offset, &dst_offset, dst_size,
+                                                                src, &src_offset, src_size, end_op);
+    return encode_compress_stream_result(result, dst_offset, src_offset);
+}
+
+/*
+ * Class:     com_github_luben_zstd_ZstdCompressCtx
+ * Method:    compressByteArrayStream0
+ * Signature: (J[BIII[BIIII)J
+ */
+JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressByteArrayStream0
+  (JNIEnv *env, jclass jctx, jlong ptr, jbyteArray dst, jint dst_array_offset, jint dst_offset, jint dst_size,
+   jbyteArray src, jint src_array_offset, jint src_offset, jint src_size, jint end_op) {
+    size_t result = compress_byte_array_stream(env, ptr, dst, dst_array_offset, &dst_offset, dst_size, src,
+                                               src_array_offset, &src_offset, src_size, end_op);
+    return encode_compress_stream_result(result, dst_offset, src_offset);
 }
 
 /*

--- a/src/test/scala/Zstd.scala
+++ b/src/test/scala/Zstd.scala
@@ -1395,7 +1395,7 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
           val compressedBuffer = ByteBuffer.allocateDirect(Zstd.compressBound(size).toInt)
           while (inputBuffer.hasRemaining) {
             compressedBuffer.limit(compressedBuffer.position() + 1)
-            cctx.compressDirectByteBufferStream(compressedBuffer, inputBuffer, EndDirective.CONTINUE)
+            cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.CONTINUE)
           }
 
           var frameProgression = cctx.getFrameProgression()
@@ -1403,7 +1403,7 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
           assert(frameProgression.getFlushed() == compressedBuffer.position())
 
           compressedBuffer.limit(compressedBuffer.capacity())
-          val done = cctx.compressDirectByteBufferStream(compressedBuffer, inputBuffer, EndDirective.END)
+          val done = cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.END)
           assert(done)
 
           frameProgression = cctx.getFrameProgression()
@@ -1426,6 +1426,101 @@ class ZstdSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
           val comparison = inputBuffer.compareTo(decompressedBuffer)
           assert(comparison == 0 && Zstd.decompressedSize(compressedBuffer) == size && Zstd.getFrameContentSize(compressedBuffer) == size && Zstd.findFrameCompressedSize(compressedBuffer) == (compressedBuffer.limit() - compressedBuffer.position()))
         }
+      }
+    }.get
+  }
+
+  Seq(
+    (false, true, "a heap source and direct destination"),
+    (true, false, "a direct source and heap destination"),
+    (false, false, "heap source and destination")
+  ).foreach { case (sourceDirect, destinationDirect, description) =>
+    it should s"roundtrip with $description" in {
+      Using.Manager { use =>
+        val cctx = use(new ZstdCompressCtx())
+        val dctx = use(new ZstdDecompressCtx())
+        forAll { input: Array[Byte] =>
+          {
+            val size = input.length
+            val sourceStorage = if (sourceDirect) ByteBuffer.allocateDirect(size + 16) else ByteBuffer.allocate(size + 16)
+            sourceStorage.position(5)
+            val writableInput = sourceStorage.slice()
+            writableInput.position(3)
+            writableInput.put(input)
+            val sourceLimit = writableInput.position()
+            val sourceStart = 3
+            writableInput.position(sourceStart)
+            val inputBuffer = if (sourceDirect) writableInput.asReadOnlyBuffer() else writableInput
+
+            cctx.reset()
+            cctx.setPledgedSrcSize(size)
+            val compressedCapacity = Zstd.compressBound(size).toInt + 16
+            val compressedStorage = if (destinationDirect)
+              ByteBuffer.allocateDirect(compressedCapacity)
+            else
+              ByteBuffer.allocate(compressedCapacity)
+            compressedStorage.position(5)
+            val compressedBuffer = compressedStorage.slice()
+            compressedBuffer.position(4)
+            val compressedStart = compressedBuffer.position()
+
+            inputBuffer.limit(sourceStart + size / 2)
+            while (inputBuffer.hasRemaining) {
+              compressedBuffer.limit(compressedBuffer.position() + 1)
+              cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.CONTINUE)
+            }
+
+            if (size > 1) {
+              compressedBuffer.limit(compressedBuffer.capacity())
+              assert(cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.FLUSH))
+            }
+
+            inputBuffer.limit(sourceLimit)
+            while (inputBuffer.hasRemaining) {
+              compressedBuffer.limit(compressedBuffer.position() + 1)
+              cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.CONTINUE)
+            }
+
+            compressedBuffer.limit(compressedBuffer.capacity())
+            assert(cctx.compressByteBufferStream(compressedBuffer, inputBuffer, EndDirective.END))
+            assert(inputBuffer.position() == sourceLimit)
+
+            val compressedEnd = compressedBuffer.position()
+            val compressed = new Array[Byte](compressedEnd - compressedStart)
+            compressedBuffer.position(compressedStart)
+            compressedBuffer.limit(compressedEnd)
+            compressedBuffer.get(compressed)
+            val compressedFrame = ByteBuffer.allocateDirect(compressed.length)
+            compressedFrame.put(compressed)
+            compressedFrame.flip()
+
+            val decompressedBuffer = ByteBuffer.allocateDirect(size)
+            dctx.reset()
+            while (compressedFrame.hasRemaining) {
+              dctx.decompressDirectByteBufferStream(decompressedBuffer, compressedFrame)
+            }
+
+            val decompressed = new Array[Byte](size)
+            decompressedBuffer.flip()
+            decompressedBuffer.get(decompressed)
+            assert(decompressed.toSeq == input.toSeq)
+          }
+        }
+      }.get
+    }
+  }
+
+  "streaming compression with ByteBuffers" should "reject unsupported buffers" in {
+    Using.Manager { use =>
+      val cctx = use(new ZstdCompressCtx())
+      assertThrows[IllegalArgumentException] {
+        cctx.compressByteBufferStream(ByteBuffer.allocate(64).asReadOnlyBuffer(), ByteBuffer.allocate(1), EndDirective.CONTINUE)
+      }
+      assertThrows[IllegalArgumentException] {
+        cctx.compressByteBufferStream(ByteBuffer.allocateDirect(64).asReadOnlyBuffer(), ByteBuffer.allocate(1), EndDirective.CONTINUE)
+      }
+      assertThrows[IllegalArgumentException] {
+        cctx.compressByteBufferStream(ByteBuffer.allocateDirect(64), ByteBuffer.allocate(1).asReadOnlyBuffer(), EndDirective.CONTINUE)
       }
     }.get
   }


### PR DESCRIPTION
This change adds ZstdCompressCtx.compressByteBufferStream(...) with support for both direct and array-backed heap ByteBuffers. The existing compressDirectByteBufferStream(...) only accepts direct buffers, while heap buffers created through ByteBuffer.allocate(...), ByteBuffer.wrap(...), and heap slice() are common in Java/NIO code.

The motivating use case comes from implementing OpenSearch translog compression: translog data is held on heap, while the compressed output is written into an off-heap direct I/O buffer. Previously, this required allocating an additional direct input buffer and copying the translog data before compression.